### PR TITLE
ci: build and publish the parakeet-cli container image to ghcr

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Keep the build context small and reproducible. The ggml submodule source
+# under third_party/ggml IS needed and must stay in the context.
+
+.git
+.github
+.venv
+.cache
+.claude
+build*/
+build-shared/
+
+# Large / derived artifacts that never belong in an image build.
+models/*
+!models/MANIFEST.md
+*.gguf
+benchmarks/audio/
+benchmarks/models/
+benchmarks/media/
+
+# Local scratch.
+__pycache__/
+*.pyc
+third_party/.ggml-patch.lock

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,12 @@
 name: docker
 
-# Build the parakeet.cpp container images and publish them to GitHub Container
-# Registry (ghcr.io/<owner>/parakeet.cpp).
+# Build the parakeet-cli container images and publish them to GitHub Container
+# Registry (ghcr.io/<owner>/parakeet.cpp-cli).
+#
+# Each variant (cpu, cuda) is a multi-arch image (linux/amd64 + linux/arm64).
+# Every arch is built natively on its own runner (no QEMU): amd64 on
+# ubuntu-24.04, arm64 on ubuntu-24.04-arm. The per-arch images are pushed by
+# digest, then a merge job assembles one multi-arch manifest per variant.
 #
 # On pull_request the images are built but NOT pushed, so the Dockerfile stays
 # a merge gate. On push to the default branch, tags, and manual dispatch the
@@ -20,8 +25,12 @@ env:
   IMAGE_NAME: ${{ github.repository }}-cli
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  # -------------------------------------------------------------------------
+  # build: one job per (variant, arch). Builds natively on the matching runner
+  # and pushes the image by digest (untagged). PRs build only (cache-only).
+  # -------------------------------------------------------------------------
+  build:
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -30,15 +39,29 @@ jobs:
       matrix:
         include:
           - variant: cpu
+            arch: amd64
+            runner: ubuntu-24.04
             build_base: ubuntu:24.04
             runtime_base: ubuntu:24.04
             cmake_args: ""
-            suffix: ""
+          - variant: cpu
+            arch: arm64
+            runner: ubuntu-24.04-arm
+            build_base: ubuntu:24.04
+            runtime_base: ubuntu:24.04
+            cmake_args: ""
           - variant: cuda
+            arch: amd64
+            runner: ubuntu-24.04
             build_base: nvidia/cuda:12.6.2-devel-ubuntu24.04
             runtime_base: nvidia/cuda:12.6.2-runtime-ubuntu24.04
             cmake_args: "-DPARAKEET_GGML_CUDA=ON"
-            suffix: "-cuda"
+          - variant: cuda
+            arch: arm64
+            runner: ubuntu-24.04-arm
+            build_base: nvidia/cuda:12.6.2-devel-ubuntu24.04
+            runtime_base: nvidia/cuda:12.6.2-runtime-ubuntu24.04
+            cmake_args: "-DPARAKEET_GGML_CUDA=ON"
     steps:
       - name: Checkout (with submodules)
         uses: actions/checkout@v4
@@ -51,6 +74,76 @@ jobs:
       # Only authenticate when we actually push (i.e. not on pull_request).
       - name: Log in to ghcr.io
         if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest (${{ matrix.variant }}/${{ matrix.arch }})
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          build-args: |
+            BUILD_BASE=${{ matrix.build_base }}
+            RUNTIME_BASE=${{ matrix.runtime_base }}
+            CMAKE_EXTRA_ARGS=${{ matrix.cmake_args }}
+          # PRs: build only (cache-only, nothing pushed). Otherwise push the
+          # image by digest so the merge job can stitch the arches together.
+          outputs: ${{ github.event_name != 'pull_request' && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) || 'type=cacheonly' }}
+          cache-from: type=gha,scope=${{ matrix.variant }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}-${{ matrix.arch }}
+
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.variant }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # -------------------------------------------------------------------------
+  # merge: combine the per-arch digests of each variant into one multi-arch
+  # manifest and tag it. Skipped on pull_request (nothing was pushed).
+  # -------------------------------------------------------------------------
+  merge:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: cpu
+            suffix: ""
+          - variant: cuda
+            suffix: "-cuda"
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.variant }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -71,17 +164,14 @@ jobs:
             type=ref,event=tag
             type=sha
 
-      - name: Build and push (${{ matrix.variant }})
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          build-args: |
-            BUILD_BASE=${{ matrix.build_base }}
-            RUNTIME_BASE=${{ matrix.runtime_base }}
-            CMAKE_EXTRA_ARGS=${{ matrix.cmake_args }}
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.variant }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
+      - name: Create multi-arch manifest and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest${{ matrix.suffix }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,87 @@
+name: docker
+
+# Build the parakeet.cpp container images and publish them to GitHub Container
+# Registry (ghcr.io/<owner>/parakeet.cpp).
+#
+# On pull_request the images are built but NOT pushed, so the Dockerfile stays
+# a merge gate. On push to the default branch, tags, and manual dispatch the
+# images are pushed.
+on:
+  push:
+    branches: [master]
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  # Named for the binary it ships, so a future server image can live alongside
+  # it (e.g. parakeet.cpp-server). Resolves to <owner>/parakeet.cpp-cli.
+  IMAGE_NAME: ${{ github.repository }}-cli
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: cpu
+            build_base: ubuntu:24.04
+            runtime_base: ubuntu:24.04
+            cmake_args: ""
+            suffix: ""
+          - variant: cuda
+            build_base: nvidia/cuda:12.6.2-devel-ubuntu24.04
+            runtime_base: nvidia/cuda:12.6.2-runtime-ubuntu24.04
+            cmake_args: "-DPARAKEET_GGML_CUDA=ON"
+            suffix: "-cuda"
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Only authenticate when we actually push (i.e. not on pull_request).
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # cpu  -> latest, sha-xxxx, vX.Y.Z
+          # cuda -> latest-cuda, sha-xxxx-cuda, vX.Y.Z-cuda
+          flavor: |
+            suffix=${{ matrix.suffix }},onlatest=true
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha
+
+      - name: Build and push (${{ matrix.variant }})
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            BUILD_BASE=${{ matrix.build_base }}
+            RUNTIME_BASE=${{ matrix.runtime_base }}
+            CMAKE_EXTRA_ARGS=${{ matrix.cmake_args }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.variant }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.variant }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,9 +12,10 @@ name: docker
 # architectures (sm_120 + sm_121); that is what makes the arm64 CUDA image run
 # on GB10 / Grace-Blackwell (DGX Spark). CUDA 12.6 tops out at sm_90.
 #
-# On pull_request the images are built but NOT pushed, so the Dockerfile stays
-# a merge gate. On push to the default branch, tags, and manual dispatch the
-# images are pushed.
+# pull_request builds the CPU variant only, as a fast Dockerfile gate. The CUDA
+# build takes tens of minutes (it compiles many GPU architectures), so it runs
+# only on push to the default branch, tags, and manual dispatch, all of which
+# also push the image. Use workflow_dispatch to exercise CUDA before merging.
 on:
   push:
     branches: [master]
@@ -30,42 +31,41 @@ env:
 
 jobs:
   # -------------------------------------------------------------------------
+  # setup: choose the build matrix for this event. PRs get CPU only (fast
+  # gate); everything else gets CPU + CUDA.
+  # -------------------------------------------------------------------------
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - name: Select build matrix
+        id: set
+        run: |
+          CPU='{"variant":"cpu","arch":"amd64","runner":"ubuntu-24.04","build_base":"ubuntu:24.04","runtime_base":"ubuntu:24.04","cmake_args":"","cuda_archs":""},{"variant":"cpu","arch":"arm64","runner":"ubuntu-24.04-arm","build_base":"ubuntu:24.04","runtime_base":"ubuntu:24.04","cmake_args":"","cuda_archs":""}'
+          # CUDA: drop the libcuda driver-lib dependency (GGML_CUDA_NO_VMM) since
+          # the build container has no GPU driver. amd64 takes ggml's default
+          # (broad) arch list; arm64 only targets Grace GPUs (Hopper + GB10).
+          CUDA='{"variant":"cuda","arch":"amd64","runner":"ubuntu-24.04","build_base":"nvidia/cuda:13.0.1-devel-ubuntu24.04","runtime_base":"nvidia/cuda:13.0.1-runtime-ubuntu24.04","cmake_args":"-DPARAKEET_GGML_CUDA=ON -DGGML_CUDA_NO_VMM=ON","cuda_archs":""},{"variant":"cuda","arch":"arm64","runner":"ubuntu-24.04-arm","build_base":"nvidia/cuda:13.0.1-devel-ubuntu24.04","runtime_base":"nvidia/cuda:13.0.1-runtime-ubuntu24.04","cmake_args":"-DPARAKEET_GGML_CUDA=ON -DGGML_CUDA_NO_VMM=ON","cuda_archs":"90;121-real"}'
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "matrix={\"include\":[${CPU}]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix={\"include\":[${CPU},${CUDA}]}" >> "$GITHUB_OUTPUT"
+          fi
+
+  # -------------------------------------------------------------------------
   # build: one job per (variant, arch). Builds natively on the matching runner
   # and pushes the image by digest (untagged). PRs build only (cache-only).
   # -------------------------------------------------------------------------
   build:
+    needs: setup
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - variant: cpu
-            arch: amd64
-            runner: ubuntu-24.04
-            build_base: ubuntu:24.04
-            runtime_base: ubuntu:24.04
-            cmake_args: ""
-          - variant: cpu
-            arch: arm64
-            runner: ubuntu-24.04-arm
-            build_base: ubuntu:24.04
-            runtime_base: ubuntu:24.04
-            cmake_args: ""
-          - variant: cuda
-            arch: amd64
-            runner: ubuntu-24.04
-            build_base: nvidia/cuda:13.0.1-devel-ubuntu24.04
-            runtime_base: nvidia/cuda:13.0.1-runtime-ubuntu24.04
-            cmake_args: "-DPARAKEET_GGML_CUDA=ON"
-          - variant: cuda
-            arch: arm64
-            runner: ubuntu-24.04-arm
-            build_base: nvidia/cuda:13.0.1-devel-ubuntu24.04
-            runtime_base: nvidia/cuda:13.0.1-runtime-ubuntu24.04
-            cmake_args: "-DPARAKEET_GGML_CUDA=ON"
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     steps:
       - name: Checkout (with submodules)
         uses: actions/checkout@v4
@@ -95,6 +95,7 @@ jobs:
             BUILD_BASE=${{ matrix.build_base }}
             RUNTIME_BASE=${{ matrix.runtime_base }}
             CMAKE_EXTRA_ARGS=${{ matrix.cmake_args }}
+            CUDA_ARCHS=${{ matrix.cuda_archs }}
           # PRs: build only (cache-only, nothing pushed). Otherwise push the
           # image by digest so the merge job can stitch the arches together.
           outputs: ${{ github.event_name != 'pull_request' && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) || 'type=cacheonly' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,10 @@ name: docker
 # ubuntu-24.04, arm64 on ubuntu-24.04-arm. The per-arch images are pushed by
 # digest, then a merge job assembles one multi-arch manifest per variant.
 #
+# The CUDA images use the CUDA 13 base so ggml compiles the Blackwell
+# architectures (sm_120 + sm_121); that is what makes the arm64 CUDA image run
+# on GB10 / Grace-Blackwell (DGX Spark). CUDA 12.6 tops out at sm_90.
+#
 # On pull_request the images are built but NOT pushed, so the Dockerfile stays
 # a merge gate. On push to the default branch, tags, and manual dispatch the
 # images are pushed.
@@ -53,14 +57,14 @@ jobs:
           - variant: cuda
             arch: amd64
             runner: ubuntu-24.04
-            build_base: nvidia/cuda:12.6.2-devel-ubuntu24.04
-            runtime_base: nvidia/cuda:12.6.2-runtime-ubuntu24.04
+            build_base: nvidia/cuda:13.0.1-devel-ubuntu24.04
+            runtime_base: nvidia/cuda:13.0.1-runtime-ubuntu24.04
             cmake_args: "-DPARAKEET_GGML_CUDA=ON"
           - variant: cuda
             arch: arm64
             runner: ubuntu-24.04-arm
-            build_base: nvidia/cuda:12.6.2-devel-ubuntu24.04
-            runtime_base: nvidia/cuda:12.6.2-runtime-ubuntu24.04
+            build_base: nvidia/cuda:13.0.1-devel-ubuntu24.04
+            runtime_base: nvidia/cuda:13.0.1-runtime-ubuntu24.04
             cmake_args: "-DPARAKEET_GGML_CUDA=ON"
     steps:
       - name: Checkout (with submodules)

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@
 #
 #   CUDA:
 #     docker build -t parakeet.cpp:cuda \
-#       --build-arg BUILD_BASE=nvidia/cuda:12.6.2-devel-ubuntu24.04 \
-#       --build-arg RUNTIME_BASE=nvidia/cuda:12.6.2-runtime-ubuntu24.04 \
+#       --build-arg BUILD_BASE=nvidia/cuda:13.0.1-devel-ubuntu24.04 \
+#       --build-arg RUNTIME_BASE=nvidia/cuda:13.0.1-runtime-ubuntu24.04 \
 #       --build-arg CMAKE_EXTRA_ARGS=-DPARAKEET_GGML_CUDA=ON .
 #
 # The build context must be a checkout with the ggml submodule populated

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,12 @@
 #   CPU (default):
 #     docker build -t parakeet.cpp:cpu .
 #
-#   CUDA:
+#   CUDA (GGML_CUDA_NO_VMM=ON drops the libcuda driver-lib link dependency,
+#   which a GPU-less build container does not have):
 #     docker build -t parakeet.cpp:cuda \
 #       --build-arg BUILD_BASE=nvidia/cuda:13.0.1-devel-ubuntu24.04 \
 #       --build-arg RUNTIME_BASE=nvidia/cuda:13.0.1-runtime-ubuntu24.04 \
-#       --build-arg CMAKE_EXTRA_ARGS=-DPARAKEET_GGML_CUDA=ON .
+#       --build-arg "CMAKE_EXTRA_ARGS=-DPARAKEET_GGML_CUDA=ON -DGGML_CUDA_NO_VMM=ON" .
 #
 # The build context must be a checkout with the ggml submodule populated
 # (git clone --recursive, or actions/checkout with submodules: recursive).
@@ -30,6 +31,10 @@ FROM ${BUILD_BASE} AS build
 
 # Extra cmake flags appended verbatim (e.g. -DPARAKEET_GGML_CUDA=ON).
 ARG CMAKE_EXTRA_ARGS=""
+# CUDA architectures, passed as a quoted CMAKE_CUDA_ARCHITECTURES list so the
+# ';' separator survives the shell (e.g. "90;121-real"). Empty = let ggml pick
+# its default broad list. Kept separate from CMAKE_EXTRA_ARGS for that reason.
+ARG CUDA_ARCHS=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -57,6 +62,7 @@ RUN cmake -B build \
         -DPARAKEET_BUILD_CLI=ON \
         -DPARAKEET_BUILD_TESTS=OFF \
         ${CMAKE_EXTRA_ARGS} \
+        ${CUDA_ARCHS:+"-DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}"} \
     && cmake --build build -j"$(nproc)"
 
 # Stage the binary and every backend shared library (CPU, and CUDA when built)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+# parakeet.cpp container image.
+#
+# Multi-stage build: a fat build stage compiles parakeet-cli (and the ggml
+# backends it links against), then a slim runtime stage carries only the
+# binary plus the ggml shared libraries.
+#
+# The same Dockerfile produces the CPU and CUDA variants. Select with build
+# args:
+#
+#   CPU (default):
+#     docker build -t parakeet.cpp:cpu .
+#
+#   CUDA:
+#     docker build -t parakeet.cpp:cuda \
+#       --build-arg BUILD_BASE=nvidia/cuda:12.6.2-devel-ubuntu24.04 \
+#       --build-arg RUNTIME_BASE=nvidia/cuda:12.6.2-runtime-ubuntu24.04 \
+#       --build-arg CMAKE_EXTRA_ARGS=-DPARAKEET_GGML_CUDA=ON .
+#
+# The build context must be a checkout with the ggml submodule populated
+# (git clone --recursive, or actions/checkout with submodules: recursive).
+# Models are not bundled: mount a pre-converted .gguf at runtime.
+
+ARG BUILD_BASE=ubuntu:24.04
+ARG RUNTIME_BASE=ubuntu:24.04
+
+# ---------------------------------------------------------------------------
+# build: configure + compile parakeet-cli and the ggml backends.
+# ---------------------------------------------------------------------------
+FROM ${BUILD_BASE} AS build
+
+# Extra cmake flags appended verbatim (e.g. -DPARAKEET_GGML_CUDA=ON).
+ARG CMAKE_EXTRA_ARGS=""
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# CMake auto-applies the in-tree ggml patches during configure via
+# scripts/apply_ggml_patches.sh, which uses `git apply` and therefore needs
+# third_party/ggml to be a git repo. Re-init it as a throwaway repo so this
+# works regardless of how the submodule arrived in the build context.
+RUN rm -rf third_party/ggml/.git && git -C third_party/ggml init -q
+
+# GGML_NATIVE=OFF keeps the binary portable across the CPUs that will pull the
+# published image (no host-specific ISA extensions baked in). GGML_LLAMAFILE
+# stays on (forced by CMakeLists) for the tinyBLAS SGEMM speedup.
+RUN cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DGGML_NATIVE=OFF \
+        -DPARAKEET_BUILD_CLI=ON \
+        -DPARAKEET_BUILD_TESTS=OFF \
+        ${CMAKE_EXTRA_ARGS} \
+    && cmake --build build -j"$(nproc)"
+
+# Stage the binary and every backend shared library (CPU, and CUDA when built)
+# into a clean prefix the runtime stage can copy wholesale.
+RUN mkdir -p /install/bin /install/lib \
+    && cp build/examples/cli/parakeet-cli /install/bin/ \
+    && find build -name '*.so*' -exec cp -av {} /install/lib/ \;
+
+# ---------------------------------------------------------------------------
+# runtime: slim image with just the binary and its shared libraries.
+# ---------------------------------------------------------------------------
+FROM ${RUNTIME_BASE} AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgomp1 \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /install/bin/ /usr/local/bin/
+COPY --from=build /install/lib/ /usr/local/lib/
+RUN ldconfig
+
+WORKDIR /work
+ENTRYPOINT ["parakeet-cli"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The CLI auto-selects the first GPU device the ggml registry reports, so no runti
 
 ## Docker
 
-Prebuilt images are published to GitHub Container Registry on every push to `master`. They contain just the `parakeet-cli` binary, so mount a converted `.gguf` model and your audio at runtime:
+Prebuilt images are published to GitHub Container Registry on every push to `master`. They contain just the `parakeet-cli` binary, so mount a converted `.gguf` model and your audio at runtime. Both the CPU and CUDA images are multi-arch (`linux/amd64` and `linux/arm64`), so the right one is pulled for your host automatically:
 
 ```sh
 # CPU
@@ -111,7 +111,7 @@ docker run --rm --gpus all \
   transcribe --model /models/parakeet-tdt_ctc-110m-q5_k.gguf --input /audio/speech.wav --decoder tdt
 ```
 
-To build the image yourself, see the build args at the top of the [`Dockerfile`](Dockerfile). The CPU image is the portable `GGML_NATIVE=OFF` build, so it runs on any x86-64 host.
+To build the image yourself, see the build args at the top of the [`Dockerfile`](Dockerfile). The CPU image is the portable `GGML_NATIVE=OFF` build, so it runs on any amd64 or arm64 host.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ The CLI auto-selects the first GPU device the ggml registry reports, so no runti
 
 ---
 
+## Docker
+
+Prebuilt images are published to GitHub Container Registry on every push to `master`. They contain just the `parakeet-cli` binary, so mount a converted `.gguf` model and your audio at runtime:
+
+```sh
+# CPU
+docker run --rm \
+  -v "$PWD/models:/models:ro" \
+  -v "$PWD/audio:/audio:ro" \
+  ghcr.io/mudler/parakeet.cpp-cli:latest \
+  transcribe --model /models/parakeet-tdt_ctc-110m-q5_k.gguf --input /audio/speech.wav --decoder tdt
+
+# CUDA (needs the nvidia container toolkit on the host)
+docker run --rm --gpus all \
+  -v "$PWD/models:/models:ro" -v "$PWD/audio:/audio:ro" \
+  ghcr.io/mudler/parakeet.cpp-cli:latest-cuda \
+  transcribe --model /models/parakeet-tdt_ctc-110m-q5_k.gguf --input /audio/speech.wav --decoder tdt
+```
+
+To build the image yourself, see the build args at the top of the [`Dockerfile`](Dockerfile). The CPU image is the portable `GGML_NATIVE=OFF` build, so it runs on any x86-64 host.
+
+---
+
 ## Python environment setup
 
 You need this once, for model conversion and validation. It's not needed for inference:

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ docker run --rm --gpus all \
   transcribe --model /models/parakeet-tdt_ctc-110m-q5_k.gguf --input /audio/speech.wav --decoder tdt
 ```
 
+The CUDA image is built on CUDA 13, so it covers everything from Turing up through Blackwell, including GB10 / Grace-Blackwell (DGX Spark) on arm64.
+
 To build the image yourself, see the build args at the top of the [`Dockerfile`](Dockerfile). The CPU image is the portable `GGML_NATIVE=OFF` build, so it runs on any amd64 or arm64 host.
 
 ---


### PR DESCRIPTION
Add a multi-stage Dockerfile and a docker workflow that builds the parakeet-cli image and pushes it to ghcr.io/<owner>/parakeet.cpp-cli.

- Dockerfile: fat build stage compiles parakeet-cli plus the ggml backends, a slim runtime stage carries only the binary and the ggml .so files. One Dockerfile, CPU and CUDA variants selected via BUILD_BASE / RUNTIME_BASE / CMAKE_EXTRA_ARGS build args. GGML_NATIVE=OFF so the image is portable across x86-64 hosts. The ggml submodule is re-inited as a throwaway git repo in the build stage so the CMake-driven patch step (git apply) works regardless of how the submodule arrived in the context.
- docker.yml: matrix over cpu/cuda, builds on every push/PR (build-only gate on PRs), pushes to ghcr on master + tags + dispatch. Tags via metadata-action: latest / sha / vX.Y.Z, with a -cuda suffix for the CUDA variant. Uses GITHUB_TOKEN, gha build cache.
- .dockerignore keeps the context small (excludes .git, build dirs, models, benchmark media) while keeping the ggml source.
- README: Docker section with CPU and CUDA run examples.

Verified the CPU image end to end: builds at 127 MB, parakeet-cli runs, and transcribing tests/fixtures/speech.wav with a mounted q5_k 110m model yields the exact NeMo reference transcript.

Assisted-by: Claude:claude-opus-4-8 [Claude Code]