### PR TITLE
fix: define M_PI for MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ else()
   add_library(parakeet STATIC ${PARAKEET_SRC})
 endif()
 target_include_directories(parakeet PUBLIC include PRIVATE src ${CMAKE_SOURCE_DIR}/third_party)
+target_compile_definitions(parakeet PUBLIC $<$<CXX_COMPILER_ID:MSVC>:_USE_MATH_DEFINES>)
 target_link_libraries(parakeet PUBLIC ggml)
 
 if(PARAKEET_BUILD_CLI)

--- a/src/fft.cpp
+++ b/src/fft.cpp
@@ -1,6 +1,12 @@
 #include "fft.hpp"
 #include <cassert>
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
 #include <cmath>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 #include <cstdint>
 #include <vector>
 

--- a/src/mel_gpu.cpp
+++ b/src/mel_gpu.cpp
@@ -3,7 +3,13 @@
 #include "ggml_graph.hpp"
 #include "ggml.h"
 #include <cassert>
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
 #include <cmath>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 #include <vector>
 
 namespace pk {


### PR DESCRIPTION
## Problem

On MSVC, `M_PI` is not declared by `<cmath>` unless `_USE_MATH_DEFINES` is defined before the header is included, so the build fails with `identifier "M_PI" is undefined` (#6). The constant is used in `src/fft.cpp`, `src/mel_gpu.cpp`, and the test sources.

## Fix

- In `src/fft.cpp` and `src/mel_gpu.cpp`, define `_USE_MATH_DEFINES` before `<cmath>` and add an `#ifndef M_PI` fallback, so the library sources compile regardless of toolchain or include ordering.
- In `CMakeLists.txt`, add `_USE_MATH_DEFINES` for MSVC as a `PUBLIC` compile definition on the `parakeet` target. `PUBLIC` (rather than `PRIVATE`) propagates it to consumers that link the library, so the test executables built with `-DPARAKEET_BUILD_TESTS=ON` (`test_fft`, `test_audio_io`, `test_mel_gpu`, which also use `M_PI`) get the define as well.

Non-MSVC builds are unaffected: the generator expression only emits the define for `CXX_COMPILER_ID:MSVC`, and the `#ifndef` guards are no-ops where `M_PI` is already provided.

## Testing

- Constant/define-only change; no runtime logic is modified.
- Verified the generator expression is scoped to MSVC and that the `PUBLIC` definition reaches the test targets through `target_link_libraries(<test> PRIVATE parakeet)`.

Closes #6

AI was used for assistance.
