### PR TITLE
ci(release): package parakeet-server alongside parakeet-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: release
 
-# Pre-built parakeet-cli bundles for every release (issue #21).
+# Pre-built parakeet-cli and parakeet-server bundles for every release (issue #21).
 #
-# One self-contained binary per (platform, backend) pair, packaged with the
-# LICENSE and README. BUILD_SHARED_LIBS=OFF folds the ggml backends into the
+# Two self-contained binaries (parakeet-cli + parakeet-server) per (platform,
+# backend) pair, packaged with the LICENSE and README. parakeet-server is the
+# OpenAI-compatible HTTP server (examples/server) — the same downstream value
+# llama.cpp/whisper.cpp ship as llama-server/whisper-server. It already built
+# in this workflow (PARAKEET_BUILD_SERVER defaults ON); this just packages it.
+# BUILD_SHARED_LIBS=OFF folds the ggml backends into the
 # binary (the docker images keep them shared; a download-and-run bundle should
 # not need a lib directory). GGML_NATIVE=OFF keeps the binaries portable
 # across CPUs, same as the docker images and ci.yml.
@@ -123,6 +127,7 @@ jobs:
             -DGGML_NATIVE=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DPARAKEET_BUILD_CLI=ON \
+            -DPARAKEET_BUILD_SERVER=ON \
             -DPARAKEET_BUILD_TESTS=OFF \
             ${{ matrix.cmake_args }} \
             ${CUDA_ARCHS:+"-DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}"} \
@@ -137,13 +142,16 @@ jobs:
         run: |
           out=$(./build/examples/cli/parakeet-cli 2>&1 || true)
           grep -qi usage <<<"$out"
+          out=$(./build/examples/server/parakeet-server --help 2>&1 || true)
+          grep -qi usage <<<"$out"
 
       - name: Package
         id: pack
         run: |
           BUNDLE="parakeet-${{ steps.ver.outputs.version }}-bin-linux-${{ matrix.backend }}-${{ matrix.arch }}"
           mkdir "$BUNDLE"
-          cp build/examples/cli/parakeet-cli LICENSE README.md "$BUNDLE"/
+          cp build/examples/cli/parakeet-cli build/examples/server/parakeet-server \
+             LICENSE README.md "$BUNDLE"/
           if [ "${{ matrix.backend }}" = "cuda" ]; then
             cp -P /usr/local/cuda/targets/x86_64-linux/lib/libcudart.so* \
                   /usr/local/cuda/targets/x86_64-linux/lib/libcublas.so* \
@@ -248,6 +256,7 @@ jobs:
             -DGGML_NATIVE=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DPARAKEET_BUILD_CLI=ON \
+            -DPARAKEET_BUILD_SERVER=ON \
             -DPARAKEET_BUILD_TESTS=OFF \
             ${{ matrix.cmake_args }}
 
@@ -260,13 +269,16 @@ jobs:
         run: |
           out=$(./build/examples/cli/parakeet-cli 2>&1 || true)
           grep -qi usage <<<"$out"
+          out=$(./build/examples/server/parakeet-server --help 2>&1 || true)
+          grep -qi usage <<<"$out"
 
       - name: Package
         id: pack
         run: |
           BUNDLE="parakeet-${{ steps.ver.outputs.version }}-bin-macos-${{ matrix.backend }}-${{ matrix.arch }}"
           mkdir "$BUNDLE"
-          cp build/examples/cli/parakeet-cli LICENSE README.md "$BUNDLE"/
+          cp build/examples/cli/parakeet-cli build/examples/server/parakeet-server \
+             LICENSE README.md "$BUNDLE"/
           tar -czf "$BUNDLE.tar.gz" "$BUNDLE"
           echo "bundle=$BUNDLE" >> "$GITHUB_OUTPUT"
 
@@ -385,6 +397,7 @@ jobs:
             -DGGML_NATIVE=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DPARAKEET_BUILD_CLI=ON \
+            -DPARAKEET_BUILD_SERVER=ON \
             -DPARAKEET_BUILD_TESTS=OFF \
             ${{ matrix.cmake_args }} \
             ${CUDA_ARCHS:+"-DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}"}
@@ -398,6 +411,8 @@ jobs:
         run: |
           out=$(./build/examples/cli/parakeet-cli.exe 2>&1 || true)
           grep -qi usage <<<"$out"
+          out=$(./build/examples/server/parakeet-server.exe --help 2>&1 || true)
+          grep -qi usage <<<"$out"
 
       - name: Package
         id: pack
@@ -405,7 +420,7 @@ jobs:
         run: |
           $bundle = "parakeet-${{ steps.ver.outputs.version }}-bin-win-${{ matrix.backend }}-x64"
           New-Item -ItemType Directory -Path $bundle | Out-Null
-          Copy-Item build/examples/cli/parakeet-cli.exe,LICENSE,README.md $bundle/
+          Copy-Item build/examples/cli/parakeet-cli.exe,build/examples/server/parakeet-server.exe,LICENSE,README.md $bundle/
           Compress-Archive -Path $bundle -DestinationPath "$bundle.zip"
           "bundle=$bundle" | Out-File -Append $env:GITHUB_OUTPUT
 


### PR DESCRIPTION
### What

The release workflow already **builds** `parakeet-server` (`examples/server`, the OpenAI-compatible HTTP server) on every tag — `PARAKEET_BUILD_SERVER` defaults `ON` and the configure step never disables it — but the `Package` steps copy only `parakeet-cli`, so the server never reaches the release assets.

This packages `parakeet-server` into the `bin-` bundles for every `(platform, backend)` pair (Linux cpu/vulkan/cuda x64 + cpu arm64, macOS metal arm64 + cpu x64, Windows cpu/vulkan/cuda x64), adds a `--help` usage smoke test next to the existing CLI one, and sets `-DPARAKEET_BUILD_SERVER=ON` explicitly so the intent is clear and robust to a future default change. `BUILD_SHARED_LIBS=OFF` keeps it a single self-contained binary like the CLI, so nothing extra is bundled.

### Why

`parakeet-server` is the natural way to run Parakeet as a managed local STT service over a stable HTTP contract (`POST /v1/audio/transcriptions`, single model, one request at a time) — the same downstream value `llama.cpp` and `whisper.cpp` ship as `llama-server` / `whisper-server`: a download-and-run server you can supervise and talk to over the OpenAI-compatible API, without compiling from source or pulling a container image. Follow-up to #21 (pre-built binaries) and #25 (C-API lib bundles).

### Notes

- I kept the server in the **same `bin-` bundle** as the CLI (two self-contained binaries per bundle). Happy to split it into separate `parakeet-server-…` bundles instead if you'd rather keep one binary per bundle — just say which you prefer.
- Verified locally from a clean checkout: `parakeet-server` builds and runs (`usage: parakeet-server --model … [--host] [--port] [--threads N] …`, serves `POST /v1/audio/transcriptions`). The change here is purely packaging an already-built target.
- I can trigger this workflow on the fork via `workflow_dispatch` to confirm the bundles attach before merge if that's useful.
