### PR TITLE
ci(release): build the linux vulkan bundle for arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ name: release
 # across CPUs, same as the docker images and ci.yml.
 #
 # Variants:
-#   linux   x64: cpu, vulkan, cuda      arm64: cpu
+#   linux   x64: cpu, vulkan, cuda      arm64: cpu, vulkan
 #   macos   arm64: metal                x64: cpu (cross-compiled on the arm
 #                                       runner; GitHub is retiring Intel ones)
 #   windows x64: cpu, vulkan, cuda
@@ -40,9 +40,11 @@ defaults:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # linux: cpu (x64 + arm64, native runners), vulkan (LunarG SDK), cuda
-  # (CUDA 13 apt repo). cpu/vulkan build on ubuntu-22.04 for a wider glibc
-  # range; cuda needs the ubuntu2404 CUDA repo.
+  # linux: cpu (x64 + arm64, native runners), vulkan (x64 via the LunarG SDK,
+  # arm64 via Ubuntu apt), cuda (CUDA 13 apt repo). cpu and x64 vulkan build on
+  # ubuntu-22.04 for a wider glibc range; cuda and arm64 vulkan build on
+  # ubuntu-24.04 (the CUDA 13 repo and the glslc/shaderc apt package are not
+  # available on 22.04).
   # ---------------------------------------------------------------------------
   build-linux:
     runs-on: ${{ matrix.runner }}
@@ -64,6 +66,13 @@ jobs:
           - backend: vulkan
             arch: x64
             runner: ubuntu-22.04
+            cmake_args: "-DPARAKEET_GGML_VULKAN=ON"
+            cuda_archs: ""
+          - backend: vulkan
+            arch: arm64
+            runner: ubuntu-24.04-arm
+            # LunarG ships no arm64 SDK repo, so the Vulkan toolchain comes from
+            # Ubuntu apt instead; glslc (shaderc) is packaged on 24.04, not 22.04.
             cmake_args: "-DPARAKEET_GGML_VULKAN=ON"
             cuda_archs: ""
           - backend: cuda
@@ -89,8 +98,8 @@ jobs:
             echo "version=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install Vulkan SDK (LunarG)
-        if: matrix.backend == 'vulkan'
+      - name: Install Vulkan SDK (LunarG, x64)
+        if: matrix.backend == 'vulkan' && matrix.arch == 'x64'
         run: |
           wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc \
             | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc >/dev/null
@@ -98,6 +107,16 @@ jobs:
             https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
           sudo apt-get update
           sudo apt-get install -y vulkan-sdk
+
+      - name: Install Vulkan (Ubuntu apt, arm64)
+        if: matrix.backend == 'vulkan' && matrix.arch == 'arm64'
+        # LunarG has no arm64 SDK repo. ggml's Vulkan backend needs, at build
+        # time, the loader/headers (libvulkan-dev), glslc from shaderc to compile
+        # the compute shaders, and the SPIR-V registry headers (spirv-headers) —
+        # all in the Ubuntu 24.04 archive. glslangValidator is not required.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvulkan-dev glslc spirv-headers
 
       - name: Install CUDA toolkit 13
         if: matrix.backend == 'cuda'


### PR DESCRIPTION
The release workflow ships a Vulkan bundle for linux x64 (and windows x64) but linux arm64 only gets a cpu bundle, so arm64 hosts with a Vulkan GPU have no prebuilt to pin.

This adds a `vulkan`/`arm64` entry to the `build-linux` matrix on the `ubuntu-24.04-arm` runner. LunarG publishes no arm64 SDK apt repo, so the LunarG install step is gated to x64 and arm64 installs the Vulkan toolchain from the Ubuntu archive instead:

- `libvulkan-dev` — loader + headers
- `glslc` (shaderc) — compiles ggml's compute shaders (`find_package(Vulkan COMPONENTS glslc REQUIRED)`)
- `spirv-headers` — the SPIR-V registry headers (`find_package(SPIRV-Headers CONFIG REQUIRED)`)

`glslangValidator` is not required. `ubuntu-24.04-arm` rather than `22.04` because `glslc`/`shaderc` is packaged on noble but not jammy — the same reason the cuda job already uses 24.04. The entry produces `parakeet-<ver>-bin-linux-vulkan-arm64.tar.gz` (and the matching `lib-` bundle) like the other variants.

Like every CI-built Vulkan/CUDA bundle this validates that the arm64 Vulkan backend **builds** — the runners have no GPU, so GPU execution is not exercised. Shader generation, the ggml Vulkan backend compile, and linkage are exercised on the native arm64 runner.

Validated end-to-end on a fork run with the free `ubuntu-24.04-arm` runner: the `vulkan`/`arm64` job is green and attaches the `bin-linux-vulkan-arm64` + `lib-linux-vulkan-arm64` bundles; the x64 LunarG path is unchanged.
