### PR TITLE
feat(server): emit per-word confidence in verbose_json

### DIFF
--- a/examples/server/openai_format.cpp
+++ b/examples/server/openai_format.cpp
@@ -72,13 +72,17 @@ Response format_transcription(const pk::Transcription& tr, Format fmt,
     b += "\"text\":\"" + json_escape(tr.text) + "\"";
     b += "}]";
     if (include_words) {
+        // Each word carries the NeMo per-word confidence (Word.conf); surface it
+        // under the same "conf" key parakeet-cli --json uses so clients can flag
+        // low-confidence spans.
         b += ",\"words\":[";
         for (size_t i = 0; i < tr.words.size(); ++i) {
             const pk::Word& w = tr.words[i];
             if (i) b += ",";
             b += "{\"word\":\"" + json_escape(w.text) + "\",";
             b += "\"start\":" + fixed(w.start, 3) + ",";
-            b += "\"end\":" + fixed(w.end, 3) + "}";
+            b += "\"end\":" + fixed(w.end, 3) + ",";
+            b += "\"conf\":" + fixed(w.conf, 4) + "}";
         }
         b += "]";
     }

--- a/tests/test_server_format.cpp
+++ b/tests/test_server_format.cpp
@@ -46,6 +46,7 @@ int main() {
     check(contains(rv.body, "\"segments\":["), "verbose segments");
     check(contains(rv.body, "\"words\":["), "verbose words present");
     check(contains(rv.body, "\"word\":\"hello\""), "verbose word entry");
+    check(contains(rv.body, "\"conf\":0.9100"), "verbose word confidence");
 
     Response rvn = format_transcription(tr, Format::kVerboseJson, 7.4, false);
     check(!contains(rvn.body, "\"words\":["), "verbose words gated off");


### PR DESCRIPTION
### What

`parakeet-server`'s `verbose_json` words array emits `word`/`start`/`end` but drops the per-word confidence the decoder already computes. This adds it under the `conf` key on each word object.

### Why

The value is already there — `pk::Word.conf` (NeMo's 'min' aggregate of the word's per-token confidences) — and `parakeet-cli --json` already surfaces it as `conf`; the server just wasn't forwarding it. Reusing the same `conf` key keeps the CLI and server output consistent. Per-word confidence lets clients flag low-confidence spans — discriminating in practice (a garbled word scores ~0.37 vs ~0.98 for clear speech on a real clip).

### Change

- `openai_format.cpp`: append `"conf"` (4 decimals) to each word — formatting-only, the value is already on the `Word`.
- `test_server_format.cpp`: assert the field is emitted.

Gated inside the existing `include_words` path, so it only appears in `verbose_json` with `timestamp_granularities[]=word`. Verified locally: `test_server_format` passes and a rebuilt server returns `{"word":"...","start":..,"end":..,"conf":0.3693}`.
