### PR TITLE
examples: iOS live streaming ASR demo

### DIFF
--- a/examples/ios/.gitignore
+++ b/examples/ios/.gitignore
@@ -1,0 +1,6 @@
+ParakeetDemo.xcodeproj/
+ParakeetDemo/Info.plist
+vendor/
+build-*/
+*.a
+ParakeetDemo/Resources/*.gguf

--- a/examples/ios/ParakeetDemo/Sources/AudioStreamer.swift
+++ b/examples/ios/ParakeetDemo/Sources/AudioStreamer.swift
@@ -1,0 +1,65 @@
+import AVFoundation
+
+/// Captures the mic and delivers 16 kHz mono float PCM in small blocks, plus a
+/// 0...1 level for the waveform. Uses AVAudioConverter to resample the hardware
+/// format (usually 44.1/48 kHz) down to the 16 kHz the model wants.
+final class AudioStreamer {
+    private let engine = AVAudioEngine()
+    private var converter: AVAudioConverter?
+    private let target = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                       sampleRate: 16000, channels: 1, interleaved: false)!
+
+    /// Called on an audio thread with resampled PCM and the block's RMS level.
+    var onPCM: (([Float], Float) -> Void)?
+
+    func start() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement, options: [])
+        try session.setActive(true)
+
+        let input = engine.inputNode
+        let hwFormat = input.outputFormat(forBus: 0)
+        converter = AVAudioConverter(from: hwFormat, to: target)
+
+        input.installTap(onBus: 0, bufferSize: 4096, format: hwFormat) { [weak self] buf, _ in
+            self?.handle(buf)
+        }
+        engine.prepare()
+        try engine.start()
+    }
+
+    func stop() {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        try? AVAudioSession.sharedInstance().setActive(false)
+    }
+
+    private func handle(_ input: AVAudioPCMBuffer) {
+        guard let converter else { return }
+        // Output capacity scaled by the sample-rate ratio (+slack).
+        let ratio = target.sampleRate / input.format.sampleRate
+        let cap = AVAudioFrameCount(Double(input.frameLength) * ratio) + 16
+        guard let out = AVAudioPCMBuffer(pcmFormat: target, frameCapacity: cap) else { return }
+
+        var fed = false
+        var err: NSError?
+        converter.convert(to: out, error: &err) { _, status in
+            if fed { status.pointee = .noDataNow; return nil }
+            fed = true
+            status.pointee = .haveData
+            return input
+        }
+        if err != nil || out.frameLength == 0 { return }
+
+        let n = Int(out.frameLength)
+        let ptr = out.floatChannelData![0]
+        let pcm = Array(UnsafeBufferPointer(start: ptr, count: n))
+
+        var sum: Float = 0
+        for v in pcm { sum += v * v }
+        let rms = (sum / Float(n)).squareRoot()
+        let level = min(1, rms * 6)   // crude visual gain
+
+        onPCM?(pcm, level)
+    }
+}

--- a/examples/ios/ParakeetDemo/Sources/ContentView.swift
+++ b/examples/ios/ParakeetDemo/Sources/ContentView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var model = TranscriberModel()
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Top: live audio waveform.
+            Waveform(levels: model.levels)
+                .frame(height: 120)
+                .padding(.horizontal)
+
+            // Middle: start / stop.
+            Button(action: model.toggle) {
+                Image(systemName: model.isRecording ? "stop.circle.fill" : "mic.circle.fill")
+                    .resizable()
+                    .frame(width: 84, height: 84)
+                    .foregroundStyle(model.isRecording ? .red : .accentColor)
+            }
+            Text(model.status).font(.footnote).foregroundStyle(.secondary)
+
+            // Language — disabled while recording (applies on next start).
+            Picker("Language", selection: $model.lang) {
+                ForEach(model.languages, id: \.code) { Text($0.name).tag($0.code) }
+            }
+            .pickerStyle(.menu)
+            .disabled(model.isRecording)
+
+            // Bottom: live transcription.
+            ScrollView {
+                Text(model.transcript.isEmpty ? "…" : model.transcript)
+                    .font(.title3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+            }
+            .background(Color(.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .padding(.horizontal)
+        }
+        .padding(.vertical)
+    }
+}
+
+/// Minimal bar waveform driven by the level ring buffer. Native Canvas, no deps.
+struct Waveform: View {
+    let levels: [Float]
+    var body: some View {
+        Canvas { ctx, size in
+            let n = levels.count
+            guard n > 0 else { return }
+            let w = size.width / CGFloat(n)
+            for (i, lvl) in levels.enumerated() {
+                let h = max(2, CGFloat(lvl) * size.height)
+                let x = CGFloat(i) * w
+                let rect = CGRect(x: x + 1, y: (size.height - h) / 2, width: w - 2, height: h)
+                ctx.fill(Path(roundedRect: rect, cornerRadius: 1), with: .color(.accentColor))
+            }
+        }
+    }
+}

--- a/examples/ios/ParakeetDemo/Sources/Parakeet-Bridging-Header.h
+++ b/examples/ios/ParakeetDemo/Sources/Parakeet-Bridging-Header.h
@@ -1,0 +1,3 @@
+// Exposes the flat C-API to Swift. parakeet_capi.h is vendored into
+// vendor/include by scripts/build_xcframework.sh (HEADER_SEARCH_PATHS points there).
+#import "parakeet_capi.h"

--- a/examples/ios/ParakeetDemo/Sources/ParakeetDemoApp.swift
+++ b/examples/ios/ParakeetDemo/Sources/ParakeetDemoApp.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+@main
+struct ParakeetDemoApp: App {
+    var body: some Scene {
+        WindowGroup { ContentView() }
+    }
+}

--- a/examples/ios/ParakeetDemo/Sources/ParakeetSession.swift
+++ b/examples/ios/ParakeetDemo/Sources/ParakeetSession.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// Thin Swift wrapper over the parakeet.cpp flat C streaming API.
+/// All calls hop onto one serial queue — the C context is not thread-safe and
+/// inference must stay off the main thread.
+final class ParakeetSession {
+    private var ctx: OpaquePointer?
+    private var stream: OpaquePointer?
+    private let queue = DispatchQueue(label: "cpp.parakeet.session")
+
+    enum SessionError: Error { case modelMissing, loadFailed(String), beginFailed(String) }
+
+    /// Loads the bundled model.gguf once. Heavy — call off the main thread.
+    init() throws {
+        guard let path = Bundle.main.path(forResource: "model", ofType: "gguf") else {
+            throw SessionError.modelMissing
+        }
+        guard let c = parakeet_capi_load(path) else {
+            throw SessionError.loadFailed("parakeet_capi_load returned null")
+        }
+        ctx = c
+    }
+
+    /// Start a fresh streaming session. `lang` is a locale or "auto".
+    func begin(lang: String = "auto") throws {
+        try queue.sync {
+            if let s = stream { parakeet_capi_stream_free(s); stream = nil }
+            guard let s = parakeet_capi_stream_begin_lang(ctx, lang) else {
+                let msg = parakeet_capi_last_error(ctx).map { String(cString: $0) } ?? "unknown"
+                throw SessionError.beginFailed(msg)
+            }
+            stream = s
+        }
+    }
+
+    /// Feed 16 kHz mono float PCM. Returns newly-finalized text (may be empty)
+    /// and the EOU/EOB event mask. Runs synchronously on the session queue.
+    func feed(_ pcm: [Float]) -> (text: String, eou: Int32) {
+        queue.sync {
+            guard let s = stream else { return ("", 0) }
+            var mask: Int32 = 0
+            let out = pcm.withUnsafeBufferPointer {
+                parakeet_capi_stream_feed(s, $0.baseAddress, Int32(pcm.count), &mask)
+            }
+            let text = out.map { String(cString: $0) } ?? ""
+            if let out { parakeet_capi_free_string(out) }
+            return (text, mask)
+        }
+    }
+
+    /// Flush the end-of-stream tail.
+    func finalize() -> String {
+        queue.sync {
+            guard let s = stream else { return "" }
+            let out = parakeet_capi_stream_finalize(s)
+            let text = out.map { String(cString: $0) } ?? ""
+            if let out { parakeet_capi_free_string(out) }
+            return text
+        }
+    }
+
+    deinit {
+        if let s = stream { parakeet_capi_stream_free(s) }
+        if let c = ctx { parakeet_capi_free(c) }
+    }
+}

--- a/examples/ios/ParakeetDemo/Sources/ParakeetSession.swift
+++ b/examples/ios/ParakeetDemo/Sources/ParakeetSession.swift
@@ -35,7 +35,7 @@ final class ParakeetSession {
 
     /// Feed 16 kHz mono float PCM. Returns newly-finalized text (may be empty)
     /// and the EOU/EOB event mask. Runs synchronously on the session queue.
-    func feed(_ pcm: [Float]) -> (text: String, eou: Int32) {
+    func feed(_ pcm: [Float]) -> (text: String, events: Int32) {
         queue.sync {
             guard let s = stream else { return ("", 0) }
             var mask: Int32 = 0

--- a/examples/ios/ParakeetDemo/Sources/TranscriberModel.swift
+++ b/examples/ios/ParakeetDemo/Sources/TranscriberModel.swift
@@ -1,0 +1,95 @@
+import AVFoundation
+import SwiftUI
+
+/// Ties the mic stream to the model and publishes UI state.
+@MainActor
+final class TranscriberModel: ObservableObject {
+    @Published var transcript = ""
+    @Published var levels: [Float] = Array(repeating: 0, count: 64)  // waveform ring
+    @Published var isRecording = false
+    @Published var status = "Tap to start"
+    @Published var lang = "en"   // forced language; "auto" tends to mis-detect
+
+    // Display name -> model locale token. Edit freely — an unknown token makes
+    // begin() throw (surfaced in `status`).
+    let languages: [(name: String, code: String)] = [
+        ("Auto-detect", "auto"), ("English", "en"), ("Spanish", "es"),
+        ("French", "fr"), ("German", "de"), ("Italian", "it"),
+        ("Portuguese", "pt"), ("Dutch", "nl"), ("Russian", "ru"),
+        ("Japanese", "ja"), ("Korean", "ko"), ("Chinese", "zh"),
+        ("Arabic", "ar"), ("Hindi", "hi"), ("Turkish", "tr"),
+    ]
+
+    private let audio = AudioStreamer()
+    private var session: ParakeetSession?
+    private let work = DispatchQueue(label: "cpp.parakeet.feed")
+
+    func toggle() { isRecording ? stop() : start() }
+
+    private func start() {
+        AVAudioSession.sharedInstance().requestRecordPermission { [weak self] granted in
+            Task { @MainActor in
+                guard let self else { return }
+                guard granted else { self.status = "Microphone denied"; return }
+                do {
+                    if self.session == nil {
+                        self.status = "Loading model…"
+                        // Load off the main thread; it's heavy.
+                        self.session = try await Task.detached { try ParakeetSession() }.value
+                    }
+                    try self.session?.begin(lang: self.lang)
+                    self.transcript = ""
+                    self.audio.onPCM = { [weak self] pcm, level in self?.feed(pcm, level) }
+                    // Start the engine off the main thread — AVAudioSession.setActive
+                    // on main logs a UI-responsiveness warning.
+                    Task.detached {
+                        do {
+                            try self.audio.start()
+                            await MainActor.run { self.isRecording = true; self.status = "Listening…" }
+                        } catch {
+                            await MainActor.run { self.status = "Error: \(error)" }
+                        }
+                    }
+                } catch {
+                    self.status = "Error: \(error)"
+                }
+            }
+        }
+    }
+
+    private func stop() {
+        audio.stop()
+        isRecording = false
+        status = "Finishing…"
+        work.async { [weak self] in
+            let tail = self?.session?.finalize() ?? ""
+            Task { @MainActor in
+                if !tail.isEmpty { self?.transcript += tail }
+                self?.status = "Tap to start"
+            }
+        }
+    }
+
+    // Called on the audio thread.
+    private nonisolated func feed(_ pcm: [Float], _ level: Float) {
+        Task { @MainActor in self.pushLevel(level) }
+        work.async { [weak self] in
+            guard let self, let s = self.session else { return }
+            let (raw, mask) = s.feed(pcm)
+            // Strip inline language tags like "<en-US>" (EOU/EOB are already gone).
+            let text = raw.contains("<")
+                ? raw.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+                : raw
+            guard !text.isEmpty || mask != 0 else { return }
+            Task { @MainActor in
+                if !text.isEmpty { self.transcript += text }
+                if mask & Int32(PARAKEET_EVENT_EOU) != 0 { self.transcript += "\n" }
+            }
+        }
+    }
+
+    private func pushLevel(_ level: Float) {
+        levels.removeFirst()
+        levels.append(level)
+    }
+}

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -1,0 +1,51 @@
+# ParakeetDemo (iOS)
+
+Live on-device streaming ASR: tap the mic, talk, watch the transcript appear.
+Waveform on top, start/stop button in the middle, live transcript at the bottom.
+
+It links `libparakeet` (static, Metal) and drives the streaming C-API
+(`parakeet_capi_stream_*`) over mic audio captured with AVAudioEngine and
+resampled to 16 kHz mono.
+
+## Build (4 steps)
+
+Requires **full Xcode** (not just Command Line Tools) — the iOS SDK and
+`xcodebuild -create-xcframework` need it. If `xcode-select -p` points at
+`CommandLineTools`, switch it once:
+
+```sh
+sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+sudo xcodebuild -license accept
+```
+
+```sh
+cd examples/ios
+
+# 1. Build the static framework for device + simulator (a few minutes).
+./scripts/build_xcframework.sh            # -> vendor/Parakeet.xcframework
+
+# 2. Drop a streaming GGUF in as the bundled model (any *streaming* parakeet model).
+mkdir -p ParakeetDemo/Resources
+cp ~/Downloads/nemotron-3.5-asr-streaming-0.6b-q4_k.NEW.gguf ParakeetDemo/Resources/model.gguf
+
+# 3. Generate the Xcode project.
+xcodegen generate                          # -> ParakeetDemo.xcodeproj
+
+# 4. Open and run on a device (or Apple-Silicon simulator).
+open ParakeetDemo.xcodeproj
+```
+
+Set your signing team in Xcode (Signing & Capabilities) before running on a
+physical device.
+
+## Notes / known ceilings
+
+- **Model must be a streaming model** (`nemotron-3.5-asr-streaming-0.6b` or
+  `parakeet_realtime_eou_120m-v1`). Offline-only GGUFs will fail `stream_begin`.
+- **q4_k is ~455 MB** in the app bundle — fine for a dev build; for the App Store
+  you'd download it on first launch instead of bundling.
+- **Metal** runs on device and on Apple-Silicon simulators. Intel simulators fall
+  back to CPU.
+- The mic→16 kHz path uses `AVAudioConverter`; language is fixed to `auto` in
+  `TranscriberModel.begin(lang:)` — change it for a forced locale.
+- This is a demo: no error UI beyond a status line, single utterance buffer.

--- a/examples/ios/README.md
+++ b/examples/ios/README.md
@@ -42,10 +42,11 @@ physical device.
 
 - **Model must be a streaming model** (`nemotron-3.5-asr-streaming-0.6b` or
   `parakeet_realtime_eou_120m-v1`). Offline-only GGUFs will fail `stream_begin`.
-- **q4_k is ~455 MB** in the app bundle — fine for a dev build; for the App Store
+- **q4_k is ~0.7 GB** in the app bundle — fine for a dev build; for the App Store
   you'd download it on first launch instead of bundling.
 - **Metal** runs on device and on Apple-Silicon simulators. Intel simulators fall
   back to CPU.
-- The mic→16 kHz path uses `AVAudioConverter`; language is fixed to `auto` in
-  `TranscriberModel.begin(lang:)` — change it for a forced locale.
+- The mic→16 kHz path uses `AVAudioConverter`. Language is chosen in the UI picker
+  (`TranscriberModel.lang`, default `en`) and passed to `ParakeetSession.begin(lang:)`;
+  `auto` tends to mis-detect, so the picker defaults to a forced locale.
 - This is a demo: no error UI beyond a status line, single utterance buffer.

--- a/examples/ios/project.yml
+++ b/examples/ios/project.yml
@@ -1,0 +1,37 @@
+# XcodeGen spec — run `xcodegen generate` here to (re)create ParakeetDemo.xcodeproj.
+# The .xcodeproj is generated, gitignored; this file is the source of truth.
+name: ParakeetDemo
+options:
+  bundleIdPrefix: cpp.parakeet
+  deploymentTarget:
+    iOS: "16.0"
+targets:
+  ParakeetDemo:
+    type: application
+    platform: iOS
+    sources:
+      - path: ParakeetDemo/Sources
+      - path: ParakeetDemo/Resources      # put model.gguf here (gitignored)
+        optional: true
+        buildPhase: resources
+    dependencies:
+      - framework: vendor/Parakeet.xcframework   # built by scripts/build_xcframework.sh
+        embed: false                              # static lib, not embedded
+      - sdk: Metal.framework
+      - sdk: Accelerate.framework
+    info:
+      path: ParakeetDemo/Info.plist
+      properties:
+        CFBundleDisplayName: Parakeet
+        UILaunchScreen: {}
+        NSMicrophoneUsageDescription: "Live on-device speech transcription."
+    settings:
+      base:
+        SWIFT_OBJC_BRIDGING_HEADER: ParakeetDemo/Sources/Parakeet-Bridging-Header.h
+        HEADER_SEARCH_PATHS: $(SRCROOT)/vendor/include
+        # -ObjC force-loads ObjC classes/categories from the static libs
+        # (ggml-metal is Objective-C); without it iOS crashes at startup with
+        # "-[OS_dispatch_mach_msg _setContext:]: unrecognized selector". See
+        # Apple QA1490. -lc++ for the C++ runtime (ggml/parakeet are C++).
+        OTHER_LDFLAGS: -ObjC -lc++
+        TARGETED_DEVICE_FAMILY: "1,2"

--- a/examples/ios/scripts/build_xcframework.sh
+++ b/examples/ios/scripts/build_xcframework.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build vendor/Parakeet.xcframework (static libparakeet + ggml, Metal embedded)
+# for iOS device + simulator, and vendor the C-API header.
+#
+# Run from examples/ios/:  ./scripts/build_xcframework.sh
+# Needs Xcode + cmake. ~a few minutes.
+set -euo pipefail
+
+# Point the toolchain at full Xcode for THIS process only (no sudo, no
+# machine-wide xcode-select change). Override by exporting DEVELOPER_DIR first.
+: "${DEVELOPER_DIR:=/Applications/Xcode.app/Contents/Developer}"
+export DEVELOPER_DIR
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"   # examples/ios
+ROOT="$(cd "$HERE/../.." && pwd)"          # repo root
+OUT="$HERE/vendor"
+rm -rf "$OUT"; mkdir -p "$OUT/include"
+cp "$ROOT/include/parakeet_capi.h" "$OUT/include/"
+
+# Common cmake flags: static everything, Metal with the shader source embedded
+# (no .metallib to ship), no host-ISA tuning (we're cross-compiling).
+COMMON=(
+  -G Xcode
+  -DCMAKE_SYSTEM_NAME=iOS
+  -DPARAKEET_BUILD_CLI=OFF -DPARAKEET_BUILD_SERVER=OFF -DPARAKEET_BUILD_TESTS=OFF
+  -DPARAKEET_SHARED=OFF
+  -DPARAKEET_GGML_METAL=ON -DGGML_METAL_EMBED_LIBRARY=ON
+  -DGGML_NATIVE=OFF -DBUILD_SHARED_LIBS=OFF
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=16.0
+  -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
+)
+
+build_slice () {           # $1 = tag, $2 = sysroot, $3 = archs
+  local tag="$1" sysroot="$2" archs="$3"
+  local b="$HERE/build-$tag"
+  rm -rf "$b"
+  # Build chatter -> stderr, so this function's stdout is ONLY the merged path
+  # (it's captured via $(...) by the caller).
+  cmake -S "$ROOT" -B "$b" "${COMMON[@]}" \
+    -DCMAKE_OSX_SYSROOT="$sysroot" -DCMAKE_OSX_ARCHITECTURES="$archs" >&2
+  cmake --build "$b" --config Release -j >&2
+  # Merge every static lib cmake produced into one fat-by-arch archive.
+  local merged="$HERE/$tag.a"
+  # Only the final per-config libs; prune Xcode's intermediate per-arch archives
+  # under build/.../Objects-normal (merging both would duplicate symbols).
+  libtool -static -o "$merged" \
+    $(find "$b" -path '*/build/*' -prune -o -name '*.a' -print | tr '\n' ' ') >&2 2>&1
+  echo "$merged"
+}
+
+DEV="$(build_slice device iphoneos arm64)"
+SIM="$(build_slice sim iphonesimulator 'arm64;x86_64')"
+
+rm -rf "$OUT/Parakeet.xcframework"
+xcodebuild -create-xcframework \
+  -library "$DEV" -headers "$OUT/include" \
+  -library "$SIM" -headers "$OUT/include" \
+  -output "$OUT/Parakeet.xcframework"
+
+echo "OK -> $OUT/Parakeet.xcframework"


### PR DESCRIPTION
Adds `examples/ios/`, a SwiftUI demo that does live, on-device streaming ASR with parakeet.cpp: tap the mic, talk, watch the transcript stream in. Waveform on top, start/stop button in the middle, live transcript at the bottom, with a language picker.

It links `libparakeet` statically (Metal, embedded shader library) and drives the streaming C-API (`parakeet_capi_stream_*`) over mic audio captured with `AVAudioEngine` and resampled to 16 kHz mono.

### Layout
- `project.yml` — XcodeGen spec (source of truth; `.xcodeproj` is generated/gitignored)
- `scripts/build_xcframework.sh` — cross-compiles libparakeet + ggml for device + simulator into `Parakeet.xcframework`
- `ParakeetDemo/Sources/` — SwiftUI app, `AVAudioEngine` capture, and a thin Swift wrapper over the streaming C-API

### Verified
- xcframework builds for `ios-arm64` + `ios-arm64_x86_64-simulator`
- App builds clean and runs on device (A16), transcribing live with a streaming model (`nemotron-3.5-asr-streaming-0.6b`)

### Caveats
- **No CI coverage** — the iOS build needs full Xcode + a streaming GGUF, so it's manual-verify / docs only.
- Requires a **streaming** model; offline-only GGUFs fail `stream_begin`.
- The model is bundled as a resource for the demo (gitignored); for production you'd download on first launch rather than ship a ~0.5 GB bundle.

Happy to gate this behind discussion if an in-tree iOS example isn't wanted.
