### PR TITLE
Add version flags to parakeet-cli and parakeet-server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,10 +97,12 @@ jobs:
         id: ver
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            version="${GITHUB_REF_NAME}"
           else
-            echo "version=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            version="${GITHUB_SHA::7}"
           fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "cmake_version=${version#v}" >> "$GITHUB_OUTPUT"
 
       - name: Install Vulkan SDK (LunarG, x64)
         if: matrix.backend == 'vulkan' && matrix.arch == 'x64'
@@ -148,6 +150,7 @@ jobs:
             -DPARAKEET_BUILD_CLI=ON \
             -DPARAKEET_BUILD_SERVER=ON \
             -DPARAKEET_BUILD_TESTS=OFF \
+            -DPARAKEET_VERSION="${{ steps.ver.outputs.cmake_version }}" \
             ${{ matrix.cmake_args }} \
             ${CUDA_ARCHS:+"-DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}"} \
             ${EXTRA:+"$EXTRA"}
@@ -155,14 +158,19 @@ jobs:
       - name: Build
         run: cmake --build build -j"$(getconf _NPROCESSORS_ONLN)"
 
-      - name: Smoke test (usage banner)
+      - name: Smoke test (usage banner and version)
         # The CLI exits nonzero when invoked bare; capture first so set -e
         # only judges the grep.
         run: |
+          expected="${{ steps.ver.outputs.cmake_version }}"
           out=$(./build/examples/cli/parakeet-cli 2>&1 || true)
           grep -qi usage <<<"$out"
+          out=$(./build/examples/cli/parakeet-cli --version)
+          grep -qx "parakeet-cli ${expected}" <<<"$out"
           out=$(./build/examples/server/parakeet-server --help 2>&1 || true)
           grep -qi usage <<<"$out"
+          out=$(./build/examples/server/parakeet-server --version)
+          grep -qx "parakeet-server ${expected}" <<<"$out"
 
       - name: Package
         id: pack
@@ -206,6 +214,7 @@ jobs:
             -DPARAKEET_SHARED=ON \
             -DPARAKEET_BUILD_CLI=OFF \
             -DPARAKEET_BUILD_TESTS=OFF \
+            -DPARAKEET_VERSION="${{ steps.ver.outputs.cmake_version }}" \
             ${{ matrix.cmake_args }} \
             ${CUDA_ARCHS:+"-DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}"} \
             ${EXTRA:+"$EXTRA"}
@@ -263,10 +272,12 @@ jobs:
         id: ver
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            version="${GITHUB_REF_NAME}"
           else
-            echo "version=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            version="${GITHUB_SHA::7}"
           fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "cmake_version=${version#v}" >> "$GITHUB_OUTPUT"
 
       - name: Configure
         run: |
@@ -277,19 +288,25 @@ jobs:
             -DPARAKEET_BUILD_CLI=ON \
             -DPARAKEET_BUILD_SERVER=ON \
             -DPARAKEET_BUILD_TESTS=OFF \
+            -DPARAKEET_VERSION="${{ steps.ver.outputs.cmake_version }}" \
             ${{ matrix.cmake_args }}
 
       - name: Build
         run: cmake --build build -j"$(getconf _NPROCESSORS_ONLN)"
 
-      - name: Smoke test (usage banner)
+      - name: Smoke test (usage banner and version)
         # The x64 binary needs Rosetta; only smoke test the native build.
         if: matrix.arch == 'arm64'
         run: |
+          expected="${{ steps.ver.outputs.cmake_version }}"
           out=$(./build/examples/cli/parakeet-cli 2>&1 || true)
           grep -qi usage <<<"$out"
+          out=$(./build/examples/cli/parakeet-cli --version)
+          grep -qx "parakeet-cli ${expected}" <<<"$out"
           out=$(./build/examples/server/parakeet-server --help 2>&1 || true)
           grep -qi usage <<<"$out"
+          out=$(./build/examples/server/parakeet-server --version)
+          grep -qx "parakeet-server ${expected}" <<<"$out"
 
       - name: Package
         id: pack
@@ -319,6 +336,7 @@ jobs:
             -DPARAKEET_SHARED=ON \
             -DPARAKEET_BUILD_CLI=OFF \
             -DPARAKEET_BUILD_TESTS=OFF \
+            -DPARAKEET_VERSION="${{ steps.ver.outputs.cmake_version }}" \
             ${{ matrix.cmake_args }}
 
       - name: Build (shared C-API lib)
@@ -378,10 +396,12 @@ jobs:
         id: ver
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            version="${GITHUB_REF_NAME}"
           else
-            echo "version=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            version="${GITHUB_SHA::7}"
           fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "cmake_version=${version#v}" >> "$GITHUB_OUTPUT"
 
       - name: Apply ggml patches (Git Bash)
         run: bash scripts/apply_ggml_patches.sh
@@ -418,20 +438,26 @@ jobs:
             -DPARAKEET_BUILD_CLI=ON \
             -DPARAKEET_BUILD_SERVER=ON \
             -DPARAKEET_BUILD_TESTS=OFF \
+            -DPARAKEET_VERSION="${{ steps.ver.outputs.cmake_version }}" \
             ${{ matrix.cmake_args }} \
             ${CUDA_ARCHS:+"-DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}"}
 
       - name: Build
         run: cmake --build build -j
 
-      - name: Smoke test (usage banner)
+      - name: Smoke test (usage banner and version)
         # The vulkan binary needs vulkan-1.dll, which the SDK install provides
         # on the runner; cpu and cuda load on a bare machine.
         run: |
+          expected="${{ steps.ver.outputs.cmake_version }}"
           out=$(./build/examples/cli/parakeet-cli.exe 2>&1 || true)
           grep -qi usage <<<"$out"
+          out=$(./build/examples/cli/parakeet-cli.exe --version)
+          grep -qx "parakeet-cli ${expected}" <<<"$out"
           out=$(./build/examples/server/parakeet-server.exe --help 2>&1 || true)
           grep -qi usage <<<"$out"
+          out=$(./build/examples/server/parakeet-server.exe --version)
+          grep -qx "parakeet-server ${expected}" <<<"$out"
 
       - name: Package
         id: pack
@@ -465,6 +491,7 @@ jobs:
             -DPARAKEET_SHARED=ON \
             -DPARAKEET_BUILD_CLI=OFF \
             -DPARAKEET_BUILD_TESTS=OFF \
+            -DPARAKEET_VERSION="${{ steps.ver.outputs.cmake_version }}" \
             ${{ matrix.cmake_args }} \
             ${CUDA_ARCHS:+"-DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHS}"}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.18)
 project(parakeet_cpp LANGUAGES C CXX)
 
+set(PARAKEET_VERSION "0.0.1" CACHE STRING "Version string returned by parakeet_version()")
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(NOT CMAKE_BUILD_TYPE)
@@ -103,6 +105,7 @@ else()
 endif()
 target_include_directories(parakeet PUBLIC include PRIVATE src ${CMAKE_SOURCE_DIR}/third_party)
 target_compile_definitions(parakeet PUBLIC $<$<CXX_COMPILER_ID:MSVC>:_USE_MATH_DEFINES>)
+target_compile_definitions(parakeet PRIVATE PARAKEET_VERSION="${PARAKEET_VERSION}")
 target_link_libraries(parakeet PUBLIC ggml)
 
 if(PARAKEET_BUILD_CLI)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ cmake --build build-shared -j
 | `PARAKEET_BUILD_TESTS`   | OFF     | Compile and register ctest targets         |
 | `PARAKEET_BUILD_CLI`     | ON      | Build `parakeet-cli`                       |
 | `PARAKEET_SHARED`        | OFF     | Build libparakeet as a shared library      |
+| `PARAKEET_VERSION`       | 0.0.1   | Version string returned by `--version`     |
 | `PARAKEET_GGML_CUDA`     | OFF     | Forward GGML_CUDA to the submodule         |
 | `PARAKEET_GGML_METAL`    | OFF     | Forward GGML_METAL to the submodule        |
 | `PARAKEET_GGML_VULKAN`   | OFF     | Forward GGML_VULKAN to the submodule       |

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -1161,6 +1161,11 @@ static int run_and_shutdown(int (*fn)(int, char**), int argc, char** argv) {
 }
 
 int main(int argc, char** argv) {
+    if (argc == 2 && (std::strcmp(argv[1], "--version") == 0 ||
+                      std::strcmp(argv[1], "-V") == 0)) {
+        std::printf("parakeet-cli %s\n", parakeet_version());
+        return 0;
+    }
     if (argc >= 3 && std::strcmp(argv[1], "info") == 0)
         return run_and_shutdown([](int, char** a) { return cmd_info(a[0]); }, 1, argv + 2);
     if (argc >= 2 && std::strcmp(argv[1], "transcribe") == 0)

--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -2,6 +2,7 @@
 #include "model_fetch.hpp"
 #include "openai_format.hpp"
 
+#include "parakeet.h"        // parakeet_version
 #include "model.hpp"          // pk::Model
 #include "transcription.hpp"  // pk::Transcription
 #include "ggml_graph.hpp"     // pk::set_num_threads, pk::shutdown_backend
@@ -71,6 +72,10 @@ int main(int argc, char** argv) {
         else if (a == "--threads") threads = std::atoi(next("--threads").c_str());
         else if (a == "--cache-dir") cache_dir = next("--cache-dir");
         else if (a == "-h" || a == "--help") { usage(); return 0; }
+        else if (a == "--version" || a == "-V") {
+            std::printf("parakeet-server %s\n", parakeet_version());
+            return 0;
+        }
         else { std::fprintf(stderr, "unknown arg: %s\n", a.c_str()); usage(); return 2; }
     }
     if (model_arg.empty()) { usage(); return 2; }

--- a/src/parakeet.cpp
+++ b/src/parakeet.cpp
@@ -6,7 +6,9 @@
 #include <stdexcept>
 #include <string>
 
+#ifndef PARAKEET_VERSION
 #define PARAKEET_VERSION "0.0.1"
+#endif
 
 extern "C" const char* parakeet_version(void) { return PARAKEET_VERSION; }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,20 @@ pk_add_test(test_capi_stream_json)
 pk_add_test(test_capi_timestamps)
 pk_add_test(test_capi_batch_json)
 
+if(TARGET parakeet-cli)
+  add_test(NAME cli_version_long COMMAND $<TARGET_FILE:parakeet-cli> --version)
+  add_test(NAME cli_version_short COMMAND $<TARGET_FILE:parakeet-cli> -V)
+  set_tests_properties(cli_version_long cli_version_short
+                       PROPERTIES PASS_REGULAR_EXPRESSION "parakeet-cli ")
+endif()
+
+if(TARGET parakeet-server)
+  add_test(NAME server_version_long COMMAND $<TARGET_FILE:parakeet-server> --version)
+  add_test(NAME server_version_short COMMAND $<TARGET_FILE:parakeet-server> -V)
+  set_tests_properties(server_version_long server_version_short
+                       PROPERTIES PASS_REGULAR_EXPRESSION "parakeet-server ")
+endif()
+
 # Server example unit tests: compile the example's pure units directly
 # (they are not part of libparakeet). No model or network needed.
 add_executable(test_server_format test_server_format.cpp


### PR DESCRIPTION
Fixes #36.

Adds `--version` / `-V` to both installed executables:

- `parakeet-cli --version`
- `parakeet-cli -V`
- `parakeet-server --version`
- `parakeet-server -V`

The version string comes from a new `PARAKEET_VERSION` CMake cache setting, with the existing `0.0.1` fallback preserved for builds that do not pass a value. Release builds now pass the tag-derived semantic version into CMake, while keeping existing release artifact names unchanged.

Validation:
- Configured with `-DPARAKEET_VERSION=9.8.7`
- Built successfully
- Ran `ctest --test-dir build-codex-version --output-on-failure -LE model`
- Verified both binaries print `9.8.7` for `--version` and `-V`