### PR TITLE
Support stdin WAV input in parakeet-cli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(PARAKEET_SRC
     src/parakeet_capi.cpp
     src/common.cpp
     src/audio_io.cpp
+    src/transcription_json.cpp
     src/model_loader.cpp
     src/backend.cpp
     src/ggml_graph.cpp

--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ parakeet-cli transcribe --model m.gguf --input audio.wav --timestamps
 #    "tokens":[{"id":..,"t":..,"conf":..}]}
 parakeet-cli transcribe --model m.gguf --input audio.wav --json
 
+# Read WAV bytes from stdin (useful with ffmpeg/curl pipelines)
+ffmpeg -i input.mp3 -f wav - | parakeet-cli transcribe --model m.gguf --input -
+
 # Print model metadata (arch, dims, mel params, vocab size, TDT durations)
 parakeet-cli info m.gguf
 

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -17,8 +17,12 @@
 #include "mel_gpu.hpp"
 #include "ggml.h"
 #include "gguf.h"
+#include "transcription_json.hpp"
 #include <chrono>
+#include <cstdlib>
 #include <fstream>
+#include <iostream>
+#include <iterator>
 #include <memory>
 #include <algorithm>
 #include <cctype>
@@ -28,6 +32,10 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
 
 static int cmd_info(const char* path) {
     pk::ModelLoader ml;
@@ -73,6 +81,40 @@ static int cmd_info(const char* path) {
     return 0;
 }
 
+static bool is_stdin_input(const std::string& input) {
+    return input == "-";
+}
+
+static std::string input_display_name(const std::string& input) {
+    return is_stdin_input(input) ? "stdin" : input;
+}
+
+static bool read_stdin_bytes(std::vector<unsigned char>& bytes) {
+#ifdef _WIN32
+    _setmode(_fileno(stdin), _O_BINARY);
+#endif
+    std::istreambuf_iterator<char> begin(std::cin);
+    std::istreambuf_iterator<char> end;
+    bytes.assign(begin, end);
+    return !bytes.empty() && !std::cin.bad();
+}
+
+static bool load_audio_arg_16k_mono(const std::string& input, pk::Audio& out) {
+    if (!is_stdin_input(input)) return pk::load_audio_16k_mono(input, out);
+
+    std::vector<unsigned char> bytes;
+    if (!read_stdin_bytes(bytes)) {
+        std::fprintf(stderr, "parakeet-cli: failed to read WAV bytes from stdin\n");
+        return false;
+    }
+    return pk::load_audio_16k_mono_from_memory(bytes.data(), bytes.size(), out);
+}
+
+static float model_frame_sec(const pk::Model& model) {
+    const pk::ParakeetConfig& cfg = model.config();
+    return (float)cfg.hop_length * (float)cfg.subsampling_factor / (float)cfg.sample_rate;
+}
+
 // Cache-aware streaming transcription for the EOU streaming model. Feeds the WAV
 // to a pk::StreamingSession in the model's exact chunk schedule, printing partial
 // text incrementally and `[EOU @ <t>s]` / `[EOB @ <t>s]` markers when events
@@ -94,8 +136,9 @@ static int cmd_transcribe_stream(const std::string& model, const std::string& in
         return 1;
     }
     pk::Audio audio;
-    if (!pk::load_audio_16k_mono(input, audio)) {
-        std::fprintf(stderr, "parakeet-cli: failed to load audio %s\n", input.c_str());
+    if (!load_audio_arg_16k_mono(input, audio)) {
+        std::string display = input_display_name(input);
+        std::fprintf(stderr, "parakeet-cli: failed to load audio %s\n", display.c_str());
         return 1;
     }
 
@@ -148,7 +191,7 @@ static int cmd_transcribe_stream(const std::string& model, const std::string& in
     return 0;
 }
 
-// parakeet-cli transcribe --model <m.gguf> --input <wav> [--decoder ctc|tdt]
+// parakeet-cli transcribe --model <m.gguf> --input <wav|-> [--decoder ctc|tdt]
 //                         [--stream]
 // Prints the transcript. Default decoder is chosen by arch (TDT for transducer
 // archs, CTC for ctc arch — matching NeMo's cur_decoder default). --stream uses
@@ -180,7 +223,7 @@ static int cmd_transcribe(int argc, char** argv) {
     }
     if (model.empty() || input.empty()) {
         std::fprintf(stderr,
-            "usage: parakeet-cli transcribe --model <m.gguf> --input <wav> "
+            "usage: parakeet-cli transcribe --model <m.gguf> --input <wav|-> "
             "[--decoder ctc|tdt] [--lang <locale>] [--stream] [--timestamps] "
             "[--threads N] [--json]\n");
         return 2;
@@ -221,6 +264,29 @@ static int cmd_transcribe(int argc, char** argv) {
 
     // --json: emit the C-API JSON document (text + word/token timestamps + conf).
     if (json) {
+        if (is_stdin_input(input)) {
+            pk::Audio audio;
+            if (!load_audio_arg_16k_mono(input, audio)) {
+                std::fprintf(stderr, "parakeet-cli: failed to load audio stdin\n");
+                return 1;
+            }
+            try {
+                std::unique_ptr<pk::Model> m = pk::Model::load(model);
+                if (!m) {
+                    std::fprintf(stderr, "parakeet-cli: failed to load model %s\n", model.c_str());
+                    return 1;
+                }
+                pk::Transcription tr =
+                    m->transcribe_with_timestamps(audio.samples, audio.sample_rate, dec, lang);
+                std::string j = pk::transcription_to_json(tr, model_frame_sec(*m));
+                std::printf("%s\n", j.c_str());
+            } catch (const std::exception& e) {
+                std::fprintf(stderr, "parakeet-cli: transcribe failed: %s\n", e.what());
+                return 1;
+            }
+            return 0;
+        }
+
         parakeet_ctx* ctx = parakeet_capi_load(model.c_str());
         if (!ctx) {
             std::fprintf(stderr, "parakeet-cli: failed to load model %s\n", model.c_str());
@@ -241,6 +307,11 @@ static int cmd_transcribe(int argc, char** argv) {
 
     // --timestamps: print one line per word `<start>-<end>  <word>  (<conf>)`.
     if (timestamps) {
+        pk::Audio audio;
+        if (is_stdin_input(input) && !load_audio_arg_16k_mono(input, audio)) {
+            std::fprintf(stderr, "parakeet-cli: failed to load audio stdin\n");
+            return 1;
+        }
         try {
             std::unique_ptr<pk::Model> m = pk::Model::load(model);
             if (!m) {
@@ -249,7 +320,9 @@ static int cmd_transcribe(int argc, char** argv) {
             }
             // `lang` (empty -> model default) selects the language prompt for
             // multilingual models; ignored by non-prompt models.
-            pk::Transcription tr = m->transcribe_path_with_timestamps(input, dec, lang);
+            pk::Transcription tr = is_stdin_input(input)
+                ? m->transcribe_with_timestamps(audio.samples, audio.sample_rate, dec, lang)
+                : m->transcribe_path_with_timestamps(input, dec, lang);
             for (const pk::Word& w : tr.words)
                 std::printf("%.2f-%.2f  %s  (%.2f)\n", w.start, w.end,
                             w.text.c_str(), w.conf);
@@ -264,7 +337,7 @@ static int cmd_transcribe(int argc, char** argv) {
     // language variant so the language prompt is selected (and an unknown locale
     // surfaces as a clean error). With no --lang keep the existing free-function
     // path so behavior for every other model is byte-for-byte unchanged.
-    if (!lang.empty()) {
+    if (!lang.empty() && !is_stdin_input(input)) {
         parakeet_ctx* ctx = parakeet_capi_load(model.c_str());
         if (!ctx) {
             std::fprintf(stderr, "parakeet-cli: failed to load model %s\n", model.c_str());
@@ -285,7 +358,21 @@ static int cmd_transcribe(int argc, char** argv) {
 
     std::string text;
     try {
-        text = pk::transcribe(model, input, dec);
+        if (is_stdin_input(input)) {
+            pk::Audio audio;
+            if (!load_audio_arg_16k_mono(input, audio)) {
+                std::fprintf(stderr, "parakeet-cli: failed to load audio stdin\n");
+                return 1;
+            }
+            std::unique_ptr<pk::Model> m = pk::Model::load(model);
+            if (!m) {
+                std::fprintf(stderr, "parakeet-cli: failed to load model %s\n", model.c_str());
+                return 1;
+            }
+            text = m->transcribe_pcm(audio.samples, audio.sample_rate, dec, lang);
+        } else {
+            text = pk::transcribe(model, input, dec);
+        }
     } catch (const std::exception& e) {
         std::fprintf(stderr, "transcribe failed: %s\n", e.what());
         return 1;
@@ -473,7 +560,7 @@ static int cmd_quantize(int argc, char** argv) {
 // ---------------------------------------------------------------------------
 
 // Append `s` to `out` as a JSON string literal (quoted), escaping per RFC 8259.
-// Mirrors append_json_string in src/parakeet_capi.cpp (UTF-8 >= 0x80 passes
+// Mirrors append_json_string in src/transcription_json.cpp (UTF-8 >= 0x80 passes
 // through verbatim).
 static void bench_json_string(std::string& out, const std::string& s) {
     out += '"';
@@ -1176,7 +1263,7 @@ int main(int argc, char** argv) {
     std::fprintf(stderr,
         "usage:\n"
         "  parakeet-cli info <model.gguf>\n"
-        "  parakeet-cli transcribe --model <model.gguf> --input <wav> "
+        "  parakeet-cli transcribe --model <model.gguf> --input <wav|-> "
         "[--decoder ctc|tdt] [--lang <locale>] [--stream] [--timestamps] "
         "[--threads N] [--json]\n"
         "  parakeet-cli quantize <in.gguf> <out.gguf> "

--- a/examples/server/openai_format.cpp
+++ b/examples/server/openai_format.cpp
@@ -38,7 +38,7 @@ std::string json_escape(const std::string& s) {
 
 static std::string fixed(double v, int prec) {
     // JSON has no NaN/Inf literal; emit 0 instead, matching the repo's
-    // append_json_float convention in src/parakeet_capi.cpp.
+    // append_json_float convention in src/transcription_json.cpp.
     if (!(v == v) || v > 1e30 || v < -1e30) return "0";
     char buf[64];
     std::snprintf(buf, sizeof(buf), "%.*f", prec, v);

--- a/src/audio_io.cpp
+++ b/src/audio_io.cpp
@@ -22,19 +22,48 @@ std::vector<float> resample_linear(const std::vector<float>& in, int in_sr, int 
     return out;
 }
 
-bool load_audio_16k_mono(const std::string& path, Audio& out) {
-    unsigned int ch = 0, sr = 0; drwav_uint64 frames = 0;
-    float* pcm = drwav_open_file_and_read_pcm_frames_f32(path.c_str(), &ch, &sr, &frames, nullptr);
-    if (!pcm) { PK_LOG("failed to open wav: %s", path.c_str()); return false; }
+namespace {
+
+bool decode_pcm_16k_mono(float* pcm, unsigned int ch, unsigned int sr,
+                         drwav_uint64 frames, Audio& out, const char* source) {
+    if (!pcm) {
+        PK_LOG("failed to open wav: %s", source);
+        return false;
+    }
+    if (ch == 0 || sr == 0) {
+        PK_LOG("invalid wav metadata: %s", source);
+        return false;
+    }
     std::vector<float> mono(frames);
     for (drwav_uint64 i = 0; i < frames; ++i) {
         double acc = 0; for (unsigned int c = 0; c < ch; ++c) acc += pcm[i*ch + c];
-        mono[i] = (float)(acc / (ch ? ch : 1));
+        mono[i] = (float)(acc / ch);
     }
-    drwav_free(pcm, nullptr);
     out.samples = resample_linear(mono, (int)sr, 16000);
     out.sample_rate = 16000;
     return true;
+}
+
+} // namespace
+
+bool load_audio_16k_mono(const std::string& path, Audio& out) {
+    unsigned int ch = 0, sr = 0; drwav_uint64 frames = 0;
+    float* pcm = drwav_open_file_and_read_pcm_frames_f32(path.c_str(), &ch, &sr, &frames, nullptr);
+    const bool ok = decode_pcm_16k_mono(pcm, ch, sr, frames, out, path.c_str());
+    if (pcm) drwav_free(pcm, nullptr);
+    return ok;
+}
+
+bool load_audio_16k_mono_from_memory(const void* data, size_t size, Audio& out) {
+    if (!data || size == 0) {
+        PK_LOG("empty wav input");
+        return false;
+    }
+    unsigned int ch = 0, sr = 0; drwav_uint64 frames = 0;
+    float* pcm = drwav_open_memory_and_read_pcm_frames_f32(data, size, &ch, &sr, &frames, nullptr);
+    const bool ok = decode_pcm_16k_mono(pcm, ch, sr, frames, out, "memory");
+    if (pcm) drwav_free(pcm, nullptr);
+    return ok;
 }
 
 } // namespace pk

--- a/src/audio_io.hpp
+++ b/src/audio_io.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstddef>
 #include <string>
 #include <vector>
 #include <cstdint>
@@ -9,6 +10,8 @@ struct Audio {
 };
 // Loads any WAV, downmixes to mono, linearly resamples to 16 kHz. Returns false on error.
 bool load_audio_16k_mono(const std::string& path, Audio& out);
+// Loads WAV bytes from memory, downmixes to mono, linearly resamples to 16 kHz.
+bool load_audio_16k_mono_from_memory(const void* data, size_t size, Audio& out);
 // Resample mono float PCM from in_sr to out_sr (linear). Exposed for reuse/testing.
 std::vector<float> resample_linear(const std::vector<float>& in, int in_sr, int out_sr);
 }

--- a/src/parakeet_capi.cpp
+++ b/src/parakeet_capi.cpp
@@ -5,6 +5,7 @@
 #include "mel.hpp"        // pk::MelFrontend
 
 #include "transcription.hpp"  // pk::Transcription, pk::Word
+#include "transcription_json.hpp"
 
 #include <cstdio>
 #include <cstdlib>
@@ -115,93 +116,6 @@ char* dup_to_c(const std::string& s) {
     std::memcpy(buf, s.data(), s.size());
     buf[s.size()] = '\0';
     return buf;
-}
-
-// Append `s` to `out` as a JSON string literal (with surrounding quotes),
-// escaping `"`, `\\`, and control characters (< 0x20) per RFC 8259. UTF-8
-// multibyte sequences (>= 0x80) pass through verbatim.
-void append_json_string(std::string& out, const std::string& s) {
-    out += '"';
-    char esc[8];
-    for (unsigned char c : s) {
-        switch (c) {
-            case '"':  out += "\\\""; break;
-            case '\\': out += "\\\\"; break;
-            case '\b': out += "\\b";  break;
-            case '\f': out += "\\f";  break;
-            case '\n': out += "\\n";  break;
-            case '\r': out += "\\r";  break;
-            case '\t': out += "\\t";  break;
-            default:
-                if (c < 0x20) {
-                    std::snprintf(esc, sizeof(esc), "\\u%04x", (unsigned)c);
-                    out += esc;
-                } else {
-                    out += (char)c;
-                }
-        }
-    }
-    out += '"';
-}
-
-// Append an int to `out` as a bare JSON number.
-void append_json_int(std::string& out, int v) {
-    char buf[16];
-    std::snprintf(buf, sizeof(buf), "%d", v);
-    out += buf;
-}
-
-// Append a float to `out` formatted with `fmt` (e.g. "%.3f"). NaN/Inf are
-// emitted as 0 (JSON has no NaN/Inf literal); confidences/times are finite here.
-void append_json_float(std::string& out, const char* fmt, float v) {
-    char buf[32];
-    if (!(v == v) || v > 1e30f || v < -1e30f) {  // NaN or huge -> 0
-        out += '0';
-        return;
-    }
-    std::snprintf(buf, sizeof(buf), fmt, v);
-    out += buf;
-}
-
-// Serialize a pk::Transcription to the C-API JSON document (see the header doc
-// on parakeet_capi_transcribe_path_json). Hand-rolled (no JSON library): times
-// (word start/end, token t) with %.3f, confidences with %.4f.
-std::string transcription_to_json(const pk::Transcription& tr, float frame_sec) {
-    std::string out;
-    out.reserve(80 + tr.words.size() * 48 + tr.tokens.size() * 40);
-    out += "{\"text\":";
-    append_json_string(out, tr.text);
-    // Encoder frame stride in seconds; lets consumers convert a frame-unit
-    // segment gap threshold (NeMo segment_gap_threshold) to the seconds gap
-    // between words when forming segments.
-    out += ",\"frame_sec\":";
-    append_json_float(out, "%.6f", frame_sec);
-    out += ",\"words\":[";
-    for (size_t i = 0; i < tr.words.size(); ++i) {
-        if (i) out += ',';
-        out += "{\"w\":";
-        append_json_string(out, tr.words[i].text);
-        out += ",\"start\":";
-        append_json_float(out, "%.3f", tr.words[i].start);
-        out += ",\"end\":";
-        append_json_float(out, "%.3f", tr.words[i].end);
-        out += ",\"conf\":";
-        append_json_float(out, "%.4f", tr.words[i].conf);
-        out += '}';
-    }
-    out += "],\"tokens\":[";
-    for (size_t i = 0; i < tr.tokens.size(); ++i) {
-        if (i) out += ',';
-        out += "{\"id\":";
-        append_json_int(out, tr.tokens[i].id);
-        out += ",\"t\":";
-        append_json_float(out, "%.3f", (float)tr.tokens[i].frame * frame_sec);
-        out += ",\"conf\":";
-        append_json_float(out, "%.4f", tr.tokens[i].conf);
-        out += '}';
-    }
-    out += "]}";
-    return out;
 }
 
 } // namespace
@@ -364,7 +278,7 @@ extern "C" char* parakeet_capi_transcribe_path_json(parakeet_ctx* ctx,
         const pk::ParakeetConfig& cfg = ctx->model->config();
         const float frame_sec =
             (float)cfg.hop_length * (float)cfg.subsampling_factor / (float)cfg.sample_rate;
-        std::string json = transcription_to_json(tr, frame_sec);
+        std::string json = pk::transcription_to_json(tr, frame_sec);
         ctx->last_error.clear();
         char* out = dup_to_c(json);
         if (!out) { ctx->last_error = "out of memory"; return nullptr; }
@@ -405,7 +319,7 @@ extern "C" char* parakeet_capi_transcribe_pcm_batch_json_lang(parakeet_ctx* ctx,
         std::string json = "[";
         for (size_t i = 0; i < trs.size(); ++i) {
             if (i) json += ',';
-            json += transcription_to_json(trs[i], frame_sec);
+            json += pk::transcription_to_json(trs[i], frame_sec);
         }
         json += "]";
         ctx->last_error.clear();
@@ -650,35 +564,35 @@ std::string stream_json(const std::string& text, int eou, int eob,
     std::string out;
     out.reserve(80 + events.size() * 36 + words.size() * 48);
     out += "{\"text\":";
-    append_json_string(out, text);
+    pk::append_json_string(out, text);
     out += ",\"eou\":";
     out += (eou ? "1" : "0");
     out += ",\"eob\":";
     out += (eob ? "1" : "0");
     out += ",\"frame_sec\":";
-    append_json_float(out, "%.6f", frame_sec);
+    pk::append_json_float(out, "%.6f", frame_sec);
     out += ",\"events\":[";
     for (size_t i = 0; i < events.size(); ++i) {
         if (i) out += ',';
         out += "{\"type\":";
         out += events[i].is_eob ? "\"eob\"" : "\"eou\"";
         out += ",\"frame\":";
-        append_json_int(out, events[i].encoder_frame);
+        pk::append_json_int(out, events[i].encoder_frame);
         out += ",\"t\":";
-        append_json_float(out, "%.3f", (float)events[i].time_sec);
+        pk::append_json_float(out, "%.3f", (float)events[i].time_sec);
         out += '}';
     }
     out += "],\"words\":[";
     for (size_t i = 0; i < words.size(); ++i) {
         if (i) out += ',';
         out += "{\"w\":";
-        append_json_string(out, words[i].text);
+        pk::append_json_string(out, words[i].text);
         out += ",\"start\":";
-        append_json_float(out, "%.3f", words[i].start);
+        pk::append_json_float(out, "%.3f", words[i].start);
         out += ",\"end\":";
-        append_json_float(out, "%.3f", words[i].end);
+        pk::append_json_float(out, "%.3f", words[i].end);
         out += ",\"conf\":";
-        append_json_float(out, "%.4f", words[i].conf);
+        pk::append_json_float(out, "%.4f", words[i].conf);
         out += '}';
     }
     out += "]}";

--- a/src/transcription_json.cpp
+++ b/src/transcription_json.cpp
@@ -1,0 +1,94 @@
+#include "transcription_json.hpp"
+
+#include <cstdio>
+
+namespace pk {
+
+// Append `s` to `out` as a JSON string literal (with surrounding quotes),
+// escaping `"`, `\\`, and control characters (< 0x20) per RFC 8259. UTF-8
+// multibyte sequences (>= 0x80) pass through verbatim.
+void append_json_string(std::string& out, const std::string& s) {
+    out += '"';
+    char esc[8];
+    for (unsigned char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\b': out += "\\b";  break;
+            case '\f': out += "\\f";  break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:
+                if (c < 0x20) {
+                    std::snprintf(esc, sizeof(esc), "\\u%04x", (unsigned)c);
+                    out += esc;
+                } else {
+                    out += (char)c;
+                }
+        }
+    }
+    out += '"';
+}
+
+// Append an int to `out` as a bare JSON number.
+void append_json_int(std::string& out, int v) {
+    char buf[16];
+    std::snprintf(buf, sizeof(buf), "%d", v);
+    out += buf;
+}
+
+// Append a float to `out` formatted with `fmt` (e.g. "%.3f"). NaN/Inf are
+// emitted as 0 (JSON has no NaN/Inf literal); confidences/times are finite here.
+void append_json_float(std::string& out, const char* fmt, float v) {
+    char buf[32];
+    if (!(v == v) || v > 1e30f || v < -1e30f) {  // NaN or huge -> 0
+        out += '0';
+        return;
+    }
+    std::snprintf(buf, sizeof(buf), fmt, v);
+    out += buf;
+}
+
+// Serialize a pk::Transcription to the C-API JSON document (see the header doc
+// on parakeet_capi_transcribe_path_json). Hand-rolled (no JSON library): times
+// (word start/end, token t) with %.3f, confidences with %.4f.
+std::string transcription_to_json(const Transcription& tr, float frame_sec) {
+    std::string out;
+    out.reserve(80 + tr.words.size() * 48 + tr.tokens.size() * 40);
+    out += "{\"text\":";
+    append_json_string(out, tr.text);
+    // Encoder frame stride in seconds; lets consumers convert a frame-unit
+    // segment gap threshold (NeMo segment_gap_threshold) to the seconds gap
+    // between words when forming segments.
+    out += ",\"frame_sec\":";
+    append_json_float(out, "%.6f", frame_sec);
+    out += ",\"words\":[";
+    for (size_t i = 0; i < tr.words.size(); ++i) {
+        if (i) out += ',';
+        out += "{\"w\":";
+        append_json_string(out, tr.words[i].text);
+        out += ",\"start\":";
+        append_json_float(out, "%.3f", tr.words[i].start);
+        out += ",\"end\":";
+        append_json_float(out, "%.3f", tr.words[i].end);
+        out += ",\"conf\":";
+        append_json_float(out, "%.4f", tr.words[i].conf);
+        out += '}';
+    }
+    out += "],\"tokens\":[";
+    for (size_t i = 0; i < tr.tokens.size(); ++i) {
+        if (i) out += ',';
+        out += "{\"id\":";
+        append_json_int(out, tr.tokens[i].id);
+        out += ",\"t\":";
+        append_json_float(out, "%.3f", (float)tr.tokens[i].frame * frame_sec);
+        out += ",\"conf\":";
+        append_json_float(out, "%.4f", tr.tokens[i].conf);
+        out += '}';
+    }
+    out += "]}";
+    return out;
+}
+
+} // namespace pk

--- a/src/transcription_json.hpp
+++ b/src/transcription_json.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "transcription.hpp"
+
+#include <string>
+
+namespace pk {
+
+void append_json_string(std::string& out, const std::string& s);
+void append_json_int(std::string& out, int v);
+void append_json_float(std::string& out, const char* fmt, float v);
+
+// Serialize a Transcription to the C-API JSON document shape:
+// {"text", "frame_sec", "words", "tokens"}.
+std::string transcription_to_json(const Transcription& tr, float frame_sec);
+
+} // namespace pk

--- a/tests/test_audio_io.cpp
+++ b/tests/test_audio_io.cpp
@@ -1,6 +1,9 @@
 #include "audio_io.hpp"
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <fstream>
+#include <iterator>
 #include <vector>
 #include <cstdint>
 
@@ -34,6 +37,27 @@ int main() {
     // not silent
     double e = 0; for (float v : a.samples) e += (double)v*v;
     if (e < 1.0) { std::fprintf(stderr, "energy too low %f\n", e); return 1; }
+
+    std::ifstream f(path, std::ios::binary);
+    std::vector<unsigned char> bytes((std::istreambuf_iterator<char>(f)),
+                                     std::istreambuf_iterator<char>());
+    if (bytes.empty()) { std::fprintf(stderr, "readback failed\n"); return 1; }
+    pk::Audio mem;
+    if (!pk::load_audio_16k_mono_from_memory(bytes.data(), bytes.size(), mem)) {
+        std::fprintf(stderr, "memory load failed\n"); return 1;
+    }
+    if (mem.sample_rate != a.sample_rate || mem.samples.size() != a.samples.size()) {
+        std::fprintf(stderr, "memory mismatch: %zu/%d vs %zu/%d\n",
+                     mem.samples.size(), mem.sample_rate, a.samples.size(), a.sample_rate);
+        return 1;
+    }
+    double max_delta = 0.0;
+    for (size_t i = 0; i < a.samples.size(); ++i)
+        max_delta = std::max(max_delta, std::fabs((double)a.samples[i] - (double)mem.samples[i]));
+    if (max_delta > 1e-6) {
+        std::fprintf(stderr, "memory sample mismatch: max_delta=%g\n", max_delta);
+        return 1;
+    }
     std::printf("audio_io ok: %zu samples @ %d Hz\n", a.samples.size(), a.sample_rate);
     return 0;
 }

--- a/tests/test_server_format.cpp
+++ b/tests/test_server_format.cpp
@@ -52,7 +52,7 @@ int main() {
     check(!contains(rvn.body, "\"words\":["), "verbose words gated off");
 
     // A NaN duration must not leak an invalid JSON literal (the fixed() guard
-    // emits 0, matching src/parakeet_capi.cpp's append_json_float).
+    // emits 0, matching src/transcription_json.cpp's append_json_float).
     Response rnan = format_transcription(tr, Format::kVerboseJson,
                                          std::nan(""), false);
     check(contains(rnan.body, "\"duration\":0"), "NaN duration -> 0");


### PR DESCRIPTION
Fixes #38

## Summary
- add `--input -` support for `parakeet-cli transcribe` across plain text, `--timestamps`, `--json`, and `--stream`
- add an internal WAV memory loader via dr_wav so stdin bytes share the same 16 kHz mono normalization as file input
- extract transcription JSON serialization into an internal helper so stdin JSON matches the existing C API output shape without adding a public C API symbol
- add a model-free audio I/O regression test for memory WAV loading and document the ffmpeg/curl pipe flow

## Validation
- `cmake -B build-codex-stdin -DPARAKEET_BUILD_TESTS=ON -DGGML_NATIVE=OFF`
- `cmake --build build-codex-stdin -j$(getconf _NPROCESSORS_ONLN)`
- `ctest --test-dir build-codex-stdin --output-on-failure -LE model`
- `./build-codex-stdin/examples/cli/parakeet-cli transcribe --model /tmp/no-such-model.gguf --input - < /tmp/pk_test_44k.wav`
- `printf 'not a wav' | ./build-codex-stdin/examples/cli/parakeet-cli transcribe --model /tmp/no-such-model.gguf --input -`
- `git diff --check`