### PR TITLE
chore: gitignore macOS and Windows metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ __pycache__/
 *.pyc
 /.cache/
 
+# OS metadata
+.DS_Store
+Thumbs.db
+
 # Benchmark large/derived files (audio + model weights) — NOT committed
 benchmarks/audio/
 benchmarks/models/


### PR DESCRIPTION
## Summary

- Ignore macOS Finder metadata files.
- Ignore Windows Explorer thumbnail database files.

## Why

These operating-system-generated files can otherwise make local checkouts and submodule consumers appear dirty.

## Validation

- `git diff --check`
