### PR TITLE
perf: move the mel buffer into the 1-item MelBatch instead of copying it

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -118,7 +118,7 @@ static EncodedAudio encode_16k(const ModelLoader& loader,
         mb1.n_mels = n_mels;
         mb1.T_max = T;
         mb1.valid_T = {T};
-        mb1.data = feats;
+        mb1.data = std::move(feats);
         std::vector<std::vector<float>> outputs;
         std::vector<int> valid_frames;
         int padded_frames = 0;
@@ -210,7 +210,7 @@ void Model::transcribe_16k_ctc_logits(const std::vector<float>& pcm16k,
     if (sub_tile > 0) {
         MelBatch mb1;
         mb1.B = 1; mb1.n_mels = n_mels; mb1.T_max = Tmel; mb1.valid_T = { Tmel };
-        mb1.data = feats;
+        mb1.data = std::move(feats);
         std::vector<std::vector<float>> eo; std::vector<int> vT;
         int dm1 = 0, To1 = 0;
         encoder.forward_batch_tiled(mb1, eo, dm1, To1, vT, sub_tile);


### PR DESCRIPTION
encode_16k and transcribe_16k_ctc_logits both assigned feats to mb1.data by copy. That branch is the long-audio path, where feats is n_mels * T floats (tens of MB for minutes of audio), so the copy doubles peak mel-buffer footprint for exactly the inputs where memory is tightest.

feats is dead after the assignment on that branch: it is only read again by the encoder.forward() call in the else branch.

Found by Coverity (COPY_INSTEAD_OF_MOVE) running over the copy of parakeet.cpp vendored in Firefox.
https://bugzilla.mozilla.org/show_bug.cgi?id=2069578


Assisted-by: Claude:claude-opus-5 [Claude Code]